### PR TITLE
changed all the 12 endpoints as requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,21 +188,117 @@ Open **http://localhost:8000**, upload any CSV/JSON from `datasets/`, click **Bu
 
 ## 06 — API Reference
 
-```
-GET    /api/config                   →  Supabase public config
-GET    /api/status                   →  System status + product count
-GET    /api/search?q=...&limit=20    →  Full-text search (PostgreSQL FTS)
-POST   /api/upload                   →  Upload CSV/JSON dataset
-POST   /api/build                    →  Train TF-IDF, SVD, VADER models
-GET    /api/recommend/{title}        →  Hybrid recommendations for an item
-GET    /api/items?page=1&per_page=50 →  Paginated product listing
-GET    /api/categories               →  All available categories
-GET    /api/weights                  →  Current α, β, γ blend weights
-PUT    /api/weights                  →  Update blend weights live
-GET    /api/purchases/{user_id}      →  User purchase history
-POST   /api/purchases                →  Record a purchase event
+## 06 — API Reference
+
+### Config
+
+```http
+GET /api/config
 ```
 
+Supabase public config
+
+---
+
+### Status
+
+```http
+GET /api/status
+```
+
+System status + product count
+
+---
+
+### Search
+
+```http
+GET /api/search?q=...&limit=20
+```
+
+Full-text search (PostgreSQL FTS)
+
+---
+
+### Upload Dataset
+
+```http
+POST /api/upload
+```
+
+Upload CSV/JSON dataset
+
+---
+
+### Build Models
+
+```http
+POST /api/build
+```
+
+Train TF-IDF, SVD, VADER models
+
+---
+
+### Recommendations
+
+```http
+GET /api/recommend/{title}
+```
+
+Hybrid recommendations for an item
+
+---
+
+### Items
+
+```http
+GET /api/items?page=1&per_page=50
+```
+
+Paginated product listing
+
+---
+
+### Categories
+
+```http
+GET /api/categories
+```
+
+All available categories
+
+---
+
+### Weights
+
+```http
+GET /api/weights
+```
+
+Current α, β, γ blend weights
+
+```http
+PUT /api/weights
+```
+
+Update blend weights live
+
+---
+
+### Purchases
+
+```http
+GET /api/purchases/{user_id}
+```
+
+User purchase history
+
+```http
+POST /api/purchases
+```
+
+Record a purchase event
 ---
 
 ## 07 — Evaluation


### PR DESCRIPTION
## What changed

* Updated Section 06 (API Reference) in `README.md`
* Converted all 12 API endpoints from a single plain-text block into individual Markdown fenced `http` code blocks
* Improved endpoint readability and GitHub syntax highlighting support

##Fixes #34

## Why

The API Reference section previously displayed endpoints as plain text, which reduced readability and did not provide syntax highlighting on GitHub.

This change improves documentation clarity and makes the API endpoints easier to read, scan, and copy for developers.

## How to test

```bash
# Open the README locally or on GitHub
# Navigate to Section 06 — API Reference

# Verify that:
# - Each endpoint is inside its own fenced code block
# - Syntax highlighting is applied
# - Formatting renders correctly in Markdown preview
```

## Screenshots (if UI change)

N/A — Documentation-only change

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md)
* [x] My code follows PEP8 style (`flake8 .`)
* [x] I have tested my changes locally
* [ ] I have added/updated tests where applicable
* [x] I can explain every line of code I've written
* [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue

Closes #<!-- issue number -->

## AI assistance disclosure

* [ ] I did not use AI assistance for this PR
* [x] I used AI assistance for: drafting and formatting the README documentation update