### PR TITLE
Enhance API reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,20 +188,65 @@ Open **http://localhost:8000**, upload any CSV/JSON from `datasets/`, click **Bu
 
 ## 06 — API Reference
 
+```http
+GET /api/config
 ```
-GET    /api/config                   →  Supabase public config
-GET    /api/status                   →  System status + product count
-GET    /api/search?q=...&limit=20    →  Full-text search (PostgreSQL FTS)
-POST   /api/upload                   →  Upload CSV/JSON dataset
-POST   /api/build                    →  Train TF-IDF, SVD, VADER models
-GET    /api/recommend/{title}        →  Hybrid recommendations for an item
-GET    /api/items?page=1&per_page=50 →  Paginated product listing
-GET    /api/categories               →  All available categories
-GET    /api/weights                  →  Current α, β, γ blend weights
-PUT    /api/weights                  →  Update blend weights live
-GET    /api/purchases/{user_id}      →  User purchase history
-POST   /api/purchases                →  Record a purchase event
+Returns Supabase public config.
+
+```http
+GET /api/status
 ```
+Returns system status and current product count.
+
+```http
+GET /api/search?q=...&limit=20
+```
+Full-text search powered by PostgreSQL FTS.
+
+```http
+POST /api/upload
+```
+Upload a CSV or JSON dataset for ingestion.
+
+```http
+POST /api/build
+```
+Train TF-IDF, SVD, and VADER models against the loaded dataset.
+
+```http
+GET /api/recommend/{title}
+```
+Return hybrid recommendations for a given item title.
+
+```http
+GET /api/items?page=1&per_page=50
+```
+Paginated product listing.
+
+```http
+GET /api/categories
+```
+List all available product categories.
+
+```http
+GET /api/weights
+```
+Retrieve the current α, β, γ blend weights.
+
+```http
+PUT /api/weights
+```
+Update blend weights live without restarting the server.
+
+```http
+GET /api/purchases/{user_id}
+```
+Fetch the purchase history for a specific user.
+
+```http
+POST /api/purchases
+```
+Record a new purchase event.
 
 ---
 


### PR DESCRIPTION
Expanded API reference section with detailed endpoints and descriptions.

## What changed

Split the single endpoint block in README.md and added blocks for users to copy the commands to use it directly via clipboard.

## Why

GitHub only syntax-highlights fenced blocks that carry a language identifier. The previous single unlabelled block rendered as flat monospace. Using http colours method tokens and path segments, making the reference easier to scan. Separate blocks also let contributors add examples under a specific endpoint without restructuring the whole section.

## How to test

No code was changed — this is a documentation-only PR. Verify rendering locally using README preview.

## Checklist
- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] My code follows PEP8 style (`flake8 .`)
- [X] I have tested my changes locally
- [X] I have added/updated tests where applicable
- [X] I can explain every line of code I've written
- [X] I have NOT used AI-generated code without understanding and attributing it

## Related issue

Closes #34

## AI assistance disclosure

- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: To clarify Markdown fenced-block syntax; applied it manually across all 12 endpoints.