### PR TITLE
feat: add custom CSS tooltip descriptions to weight sliders (#29)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -96,13 +96,13 @@
                 </button>
                 <input type="file" id="file-input" accept=".csv,.json" hidden>
             </div>
-            <div class="controls__right">
+           <div class="controls__right">
                 <div class="weight-control" id="weight-controls">
-                    <span class="weight-label">Content</span>
+                    <label class="weight-label" for="weight-alpha" data-tooltip="Content similarity weight - Higher values prioritize products similar to your search">Content</label>
                     <input type="range" id="weight-alpha" min="0" max="100" value="40" class="weight-slider">
-                    <span class="weight-label">Collab</span>
+                    <label class="weight-label" for="weight-beta" data-tooltip="Collaborative filtering weight - Higher values prioritize what similar users liked">Collab</label>
                     <input type="range" id="weight-beta" min="0" max="100" value="35" class="weight-slider">
-                    <span class="weight-label">Sentiment</span>
+                    <label class="weight-label" for="weight-gamma" data-tooltip="Sentiment weight - Higher values prioritize products with positive sentiment">Sentiment</label>
                     <input type="range" id="weight-gamma" min="0" max="100" value="25" class="weight-slider">
                 </div>
             </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1029,3 +1029,35 @@ body {
         transform: rotate(360deg);
     }
 }
+
+/* Custom tooltip styles for weight sliders - GSSoC Issue #29 */
+.weight-label {
+    position: relative;
+    cursor: help;
+}
+
+.weight-label:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1a2e;
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    white-space: nowrap;
+    z-index: 1000;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.weight-label:hover::before {
+    content: '';
+    position: absolute;
+    bottom: 115%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #1a1a2e;
+}


### PR DESCRIPTION
## What changed
Added custom CSS tooltips to Content, Collab, and Sentiment weight sliders.

## Why
Users need to understand what each weight slider controls. Tooltips provide clear explanations on hover.

## How to test
1. Navigate to the frontend folder: `cd frontend`
2. Start a local server: `python -m http.server 8000`
3. Open `http://localhost:8000`
4. Hover over "Content" → dark tooltip appears
5. Hover over "Collab" → dark tooltip appears
6. Hover over "Sentiment" → dark tooltip appears

## Screenshots
![Uploading Screenshot 2026-05-18 001050.png…]()


## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] My code follows PEP8 style
- [x] I have tested my changes locally
- [x] I can explain every line of code I've written

## Related issue
Closes #29

## AI assistance disclosure
- [x] I did not use AI assistance for this PR