### PR TITLE
Add Docker container setup for FastAPI backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.env
+.git
+.github
+.pytest_cache
+__pycache__
+*.py[cod]
+datasets/
+results/
+artifacts/
+.venv/
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/SETUP.md
+++ b/SETUP.md
@@ -53,7 +53,20 @@ python scripts/seed_mock_data.py --users 50 --purchases 2000  # Custom amounts
 python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
-### 6. Open the App
+### 6. Run with Docker
+Build the container image from the repository root:
+```bash
+docker build -t hybrid-recommender .
+```
+
+Run the FastAPI app on port 8000:
+```bash
+docker run --env-file .env -p 8000:8000 hybrid-recommender
+```
+
+The API will be available at [http://localhost:8000](http://localhost:8000).
+
+### 7. Open the App
 Navigate to: [http://localhost:8000](http://localhost:8000)
 
 ## Architecture
@@ -75,6 +88,8 @@ hybrid-recommender/
 ├── data_adapter.py      # CSV/JSON schema adapter
 ├── dataset_manager.py   # Multi-dataset manager
 ├── db.py                # Supabase client
+├── Dockerfile           # FastAPI container image
+├── .dockerignore        # Docker build exclusions
 ├── .env                 # Credentials (git-ignored)
 └── requirements.txt
 ```


### PR DESCRIPTION
## Summary
- add a `python:3.10-slim` Dockerfile for the FastAPI backend
- install dependencies from `requirements.txt`, copy the app source, expose port 8000, and run `uvicorn backend.main:app`
- add a `.dockerignore` excluding datasets, env files, Python caches, pytest caches, and local virtualenvs
- document Docker build and run commands in `SETUP.md`

Fixes #41

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest -q` ✅ 42 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall backend tests` ✅
- `git diff --check` ✅

Note: Docker is not installed in this local environment, so I could not run `docker build` here.

## GSSoC labels
The issue already has `gssoc:approved`, `level:advanced`, and `type:devops`. After review, could you please add/keep those labels on the PR and any quality label you think fits?
