### PR TITLE
fix: resolve duplicate column labels in data_adapter for datasets wit…

### DIFF
--- a/data_adapter.py
+++ b/data_adapter.py
@@ -9,10 +9,18 @@ import numpy as np
 
 def detect_column(columns, keywords):
     """Detect a column by matching against a list of keywords (case-insensitive)."""
-    for col in columns:
-        for key in keywords:
+    # First pass: exact matches
+    for key in keywords:
+        for col in columns:
+            if col.lower() == key:
+                return col
+                
+    # Second pass: substring matches
+    for key in keywords:
+        for col in columns:
             if key in col.lower():
                 return col
+                
     return None
 
 
@@ -113,6 +121,9 @@ def adapt_data(df):
     if purchase_col: rename_map[purchase_col] = 'purchases'
 
     df = df.rename(columns=rename_map)
+    # Safety net: drop duplicate columns that may arise when both an exact match
+    # (e.g. 'title') and a partial match (e.g. 'original_title') exist in the dataset.
+    df = df.loc[:, ~df.columns.duplicated()]
 
     # Fill missing safely
     if 'title' in df.columns:


### PR DESCRIPTION
## What changed
Fixed a bug in `data_adapter.py` where the `detect_column` function was incorrectly mapping partial column name matches (e.g. `original_title`) over exact matches (e.g. `title`). Also added a safety net to drop any duplicate columns immediately after the rename step.

## Why
This solves the crash reported in Issue #84. When a dataset like `movies_metadata.csv` contains both `original_title` and `title` columns, the old logic would rename `original_title` → `title`, creating two `title` columns in the DataFrame. The subsequent `df['title'].fillna()` call would then fail with:
```
cannot reindex on an axis with duplicate labels
```
This made the entire app unusable for any dataset containing both an exact and partial column name match.

## How to test
```bash
pip install -r requirements.txt
streamlit run app.py
```
1. Upload `datasets/movies_metadata.csv` through the Streamlit UI.
2. The dataset should now load successfully (45,466 rows) with no errors.
3. You can also verify directly:
```bash
python -c "from data_adapter import read_file, adapt_data; df = read_file('datasets/movies_metadata.csv'); adapted, meta = adapt_data(df); print('OK! Rows:', len(adapted))"
```

## Screenshots (if UI change)
N/A — this is a backend bug fix with no visual changes.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #84

## AI assistance disclosure
- [x] I did not use AI assistance for this PR
- [ ] I used AI assistance for: