### PR TITLE
feat: preview normalized recommender weights

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,27 @@ with st.sidebar:
     beta  = st.slider("β — Collaborative",  min_value=0.0, max_value=1.0, value=0.35, step=0.05)
     gamma = st.slider("γ — Sentiment",      min_value=0.0, max_value=1.0, value=0.25, step=0.05)
 
+    total_weight = alpha + beta + gamma
+    if total_weight == 0:
+        effective_weights = {
+            "α Content": 1 / 3,
+            "β Collaborative": 1 / 3,
+            "γ Sentiment": 1 / 3,
+        }
+        st.warning("All raw weights are zero, so the model will use equal weights.")
+    else:
+        effective_weights = {
+            "α Content": alpha / total_weight,
+            "β Collaborative": beta / total_weight,
+            "γ Sentiment": gamma / total_weight,
+        }
+
+    st.caption("Effective weights used by the model")
+    weight_cols = st.columns(3)
+    for col, (label, value) in zip(weight_cols, effective_weights.items()):
+        col.metric(label, f"{value:.3f}")
+        col.progress(value)
+
     if st.button("Apply Weights", width='stretch'):
         if st.session_state.hybrid_model is not None:
             st.session_state.hybrid_model.set_weights(alpha, beta, gamma)


### PR DESCRIPTION
## Summary
- show the effective normalized α/β/γ weights directly under the sidebar sliders
- handle the all-zero raw weight case with an equal-weight preview and warning
- render compact metrics and progress bars so users can see what the model will actually apply before clicking Apply Weights

Fixes #124

## Validation
- `git diff --check`
- `python3 -m py_compile app.py`

For GSSoC scoring, please add `gssoc:approved`, `level:beginner`, `type:feature`, and `type:design` if this is good to merge.
