### PR TITLE
feat: add lazy loading with blur placeholder for product images

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -391,6 +391,35 @@ async function loadSearchResults(query) {
     }
 }
 
+// ── Lazy Loading ────────────────────────────────────────────────────
+const lazyObserver = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        const img = entry.target;
+        img.src = img.dataset.src;
+        img.onload = () => img.classList.add('loaded');
+        lazyObserver.unobserve(img);
+    });
+}, { rootMargin: '200px 0px', threshold: 0.01 });
+
+function createLazyImage(src, alt) {
+    const img = document.createElement('img');
+    img.alt = alt || '';
+    img.setAttribute('loading', 'lazy');
+
+    if ('IntersectionObserver' in window) {
+        img.dataset.src = src;
+        img.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"%3E%3Crect width="400" height="300" fill="%23232f3e"/%3E%3C/svg%3E';
+        lazyObserver.observe(img);
+    } else {
+        img.src = src;
+        img.classList.add('loaded');
+    }
+
+    img.addEventListener('error', () => img.classList.add('error'));
+    return img;
+}
+
 function renderProducts(products, append) {
     if (!append) state.products = [];
 
@@ -399,11 +428,11 @@ function renderProducts(products, append) {
     products.forEach((p, i) => {
         state.products.push(p);
         const card = document.createElement('div');
-        card.className = 'product-card';
+        card.className = p.image ? 'product-card' : 'product-card product-card--skeleton';
         card.style.animationDelay = `${i * 50}ms`;
         card.innerHTML = `
             <div class="product-card__image">
-                ${categoryIcon(p.category)}
+                ${!p.image ? categoryIcon(p.category) : ''}
             </div>
             <div class="product-card__body">
                 ${p.category ? `<span class="product-card__category">${p.category}</span>` : ''}
@@ -423,6 +452,10 @@ function renderProducts(products, append) {
                 </button>
             </div>
         `;
+        if (p.image) {
+            const imgEl = createLazyImage(p.image, p.title);
+            card.querySelector('.product-card__image').appendChild(imgEl);
+        }
 
         // Click → get recommendations
         card.querySelector('.btn--add-cart').addEventListener('click', (e) => {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1031,3 +1031,58 @@ body {
     background: #2a2a4e;
     transform: translateY(-2px);
 }
+
+/* ── Lazy Loading ── */
+.product-card__image {
+    background: #232f3e;
+    overflow: hidden;
+}
+
+.product-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    border-radius: 4px;
+    filter: blur(10px) saturate(0.5);
+    transform: scale(1.05);
+    opacity: 0.7;
+    transition: filter 0.4s ease, transform 0.4s ease, opacity 0.4s ease;
+    will-change: transform, filter, opacity;
+}
+
+.product-card__image img.loaded {
+    filter: none;
+    transform: scale(1);
+    opacity: 1;
+}
+
+.product-card__image img.error {
+    opacity: 0;
+}
+
+/* ── Skeleton Loader ── */
+.product-card--skeleton .product-card__image {
+    background: linear-gradient(90deg, #232f3e 25%, #2d3f50 50%, #232f3e 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.4s infinite;
+    border-radius: 4px;
+}
+
+.skeleton-line {
+    height: 14px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    background: linear-gradient(90deg, #232f3e 25%, #2d3f50 50%, #232f3e 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.4s infinite;
+}
+
+.skeleton-line--title { width: 80%; }
+.skeleton-line--sub   { width: 55%; }
+.skeleton-line--price { width: 35%; }
+
+@keyframes shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}


### PR DESCRIPTION
## What changed
Added lazy loading for product images with improved UX using Intersection Observer. Implemented blur placeholder, smooth fade-in transition, and skeleton loaders for empty image states.

## Why
Product images were all loading at once on page load, causing slow initial render. With many products, this was a significant performance bottleneck. Lazy loading defers off-screen images until the user scrolls near them, reducing initial page load significantly. Reduces unnecessary network usage and makes the UI feel faster and more responsive.

## How to test
1. Run the project
# Use VS Code Live Server and open frontend/index.html
2. Open DevTools
Right-click → Inspect, Go to Network tab, Filter by Img
3. Test lazy loading behavior
Scroll through the product grid slowly.

You should observe:
Images do NOT load all at once
Images load progressively as they enter viewport

Visual verification
On page load:
Grey shimmer skeleton cards are visible
No heavy image loading at start

While scrolling:
Blur placeholder is shown first
Real image fades in smoothly after load

On broken image URL:
Image is hidden gracefully
No broken image icon is shown
Card layout remains intact

## Screenshots (if UI change)
<img width="1919" height="1031" alt="Screenshot 2026-05-19 143144" src="https://github.com/user-attachments/assets/b999237f-3236-485c-a123-52547ff18d17" />

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #69 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: I used AI assistance for: helped implement lazy loading logic, and debugging Git setup. I reviewed and understood all changes before applying.