### PR TITLE
Add empty state message with icon for no recommendations

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -912,7 +912,7 @@ function renderRecommendations(data) {
     if (!recs.length) {
     els.recsStrip.innerHTML = `
         <div class="empty-recommendations">
-            <span class="empty-icon">🔍</span>
+            <span class="empty-icon" aria-hidden="true">🔍</span>
             <p>No recommendations found. Try a different product!</p>
         </div>
     `;
@@ -968,9 +968,14 @@ async function loadRecommendations(title) {
         els.recsStrip.hidden = false;
 
         if (!recs.length) {
-            els.recsStrip.innerHTML = '<div style="padding:16px;color:var(--text-muted);">No recommendations found.</div>';
-            return;
-        }
+    els.recsStrip.innerHTML = `
+        <div class="empty-recommendations">
+            <span class="empty-icon" aria-hidden="true">🔍</span>
+            <p>No recommendations found. Try a different product!</p>
+        </div>
+    `;
+    return;
+}
     } catch {
         try {
             await loadRecommendationsOverHttp(title);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -910,9 +910,14 @@ function renderRecommendations(data) {
     els.recsStrip.hidden = false;
 
     if (!recs.length) {
-        els.recsStrip.innerHTML = '<div style="padding:16px;color:var(--text-muted);">No recommendations found.</div>';
-        return;
-    }
+    els.recsStrip.innerHTML = `
+        <div class="empty-recommendations">
+            <span class="empty-icon">🔍</span>
+            <p>No recommendations found. Try a different product!</p>
+        </div>
+    `;
+    return;
+}
 
     els.recsStrip.innerHTML = recs.map((r) => `
         <div class="rec-card" data-title="${r.title}">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1627,7 +1627,7 @@ main {
     gap: 12px;
 }
 
-.empty-icon {
+.empty-recommendations .empty-icon {
     font-size: 48px;
     opacity: 0.7;
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1615,3 +1615,25 @@ main {
 .compare-label input {
     cursor: pointer;
 }
+/* Empty state for recommendations */
+.empty-recommendations {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 48px 24px;
+    color: var(--text-muted);
+    gap: 12px;
+}
+
+.empty-icon {
+    font-size: 48px;
+    opacity: 0.7;
+}
+
+.empty-recommendations p {
+    font-size: 14px;
+    max-width: 280px;
+    line-height: 1.5;
+}


### PR DESCRIPTION
## What changed
- Added an empty state message when recommendations API returns an empty array
- Shows a friendly message: "No recommendations found. Try a different product!"
- Added a 🔍 icon and styled the empty state with CSS

## Why
Closes #35 – Improves UX by showing a clear message instead of a blank space.

## How to test
1. Start the backend with `python -m uvicorn backend.main:app --host 127.0.0.1 --port 8000`
2. Search for a product that has no recommendations (e.g., a very obscure title)
3. Scroll to the recommendations section – you should see the icon and message

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #35 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: code structure and guidance (DeepSeek)
