### PR TITLE
docs: add README badges for contributers, PRs, GSSoC and licence (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 <div align="center">
 
+[![Contributors](https://img.shields.io/github/contributors/leonagoel/hybrid-recommender.svg?style=flat-square)](https://github.com/leonagoel/hybrid-recommender/graphs/contributors)
+[![PRs Welcome](https://img.shields.io/badge/PRs_welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
+[![GSSoC 2026](https://img.shields.io/badge/GSSoC_2026-orange.svg?style=flat-square)](https://gssoc.girlscript.tech/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
 [![Python](https://img.shields.io/badge/Python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white)](https://python.org)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?style=flat-square&logo=supabase&logoColor=white)](https://supabase.com)


### PR DESCRIPTION
## What changed
<!-- Describe what you added, fixed, or changed -->
Added the Contributors, PRs Welcome, GSSoC 2026, and MIT License badges to the top of `README.md`.
I placed them directly below the ASCII title box.

## Why
<!-- Explain the problem this solves or the feature this adds -->
This makes the project look more professional and provides welcoming, easily accessible links for new contributors, fulfilling the requirements..

## How to test
<!-- Step-by-step instructions to test your changes locally -->
```bash
1. Open `README.md`
2. Verify the 4 new badges render correctly
3. Click each badge to ensure the links properly route to the contributor graph, PR guide, GSSoC site, and MIT license page.
```

## Screenshots (if UI change)
<!-- Add before/after screenshots or a screen recording -->
<img width="801" height="408" alt="image" src="https://github.com/user-attachments/assets/5362c62b-c336-4368-b000-95049100973e" />


## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #17 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for:  Understanding the URL parameters for the shields.io badges to match the project's styling.
