### PR TITLE
docs: add curl examples for all API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,56 @@ GET    /api/weights                  →  Current α, β, γ blend weights
 PUT    /api/weights                  →  Update blend weights live
 GET    /api/purchases/{user_id}      →  User purchase history
 POST   /api/purchases                →  Record a purchase event
-```
 
+06.1 — API Examples (curl)
+All examples assume the server is running at http://localhost:8000
+
+System Status
+curl http://localhost:8000/api/status
+
+Search Products
+curl "http://localhost:8000/api/search?q=laptop&limit=10"
+
+Paginated Items
+curl "http://localhost:8000/api/items?page=1&per_page=20"
+
+All Categories
+curl http://localhost:8000/api/categories
+
+Get Current Weights
+curl http://localhost:8000/api/weights
+
+Update Hybrid Weights
+curl -X PUT "http://localhost:8000/api/weights" \
+  -H "Content-Type: application/json" \
+  -d '{"alpha": 0.5, "beta": 0.3, "gamma": 0.2}'
+
+Get User Purchases
+curl "http://localhost:8000/api/purchases/user_123"
+
+Record a Purchase
+curl -X POST "http://localhost:8000/api/purchases" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "user_123", "item_id": "prod_456"}'
+
+Async Recommendation (Dispatch)
+curl -X POST "http://localhost:8000/api/recommend?item_title=Wireless%20Mouse&top_n=10"
+
+Poll Task Result (replace task_id with actual ID)
+curl "http://localhost:8000/api/task/abc123"
+
+Sync Recommendation (Legacy)
+curl "http://localhost:8000/api/recommend/Laptop"
+
+Upload Dataset
+curl -X POST "http://localhost:8000/api/upload" \
+  -F "file=@/path/to/your/dataset.csv"
+
+Build/Train Models
+curl -X POST http://localhost:8000/api/build
+
+Get Config
+curl http://localhost:8000/api/config
 ---
 
 ## 07 — Evaluation


### PR DESCRIPTION
## What changed
Added a new section **"06.1 — API Examples (curl)"** in README.md after the existing "06 — API Reference" section.

This includes curl commands for all major API endpoints:
- GET /api/status, /api/search, /api/items, /api/categories, /api/weights, /api/config
- PUT /api/weights (with JSON body)
- GET /api/purchases/{user_id}, POST /api/purchases
- POST /api/recommend (async), GET /api/task/{task_id}
- GET /api/recommend/{title} (sync legacy)
- POST /api/upload, POST /api/build

## Why
The README already listed all API endpoints but didn't provide ready-to-use curl examples. This makes it:
- Easier for new contributors to test the API immediately
- Faster for users to verify their installation is working
- More beginner-friendly documentation

## How to test
```bash
# Start the FastAPI server
python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000

# Test any curl command from the new section
curl http://localhost:8000/api/status
curl "http://localhost:8000/api/search?q=laptop&limit=10"
