### PR TITLE
fix: resolve duplicate handleSearch function in app.js

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -511,7 +511,7 @@ function handleSearchKeydown(e) {
 
 
 
-function handleSearch(query) {
+function handleAutocomplete(query) {
     if (!query || query.trim().length < 1) {
         closeSearchDropdown();
         return;
@@ -1076,10 +1076,10 @@ function populateCategoryFilter(products) {
 // ── Event Listeners ─────────────────────────────────────────────────
 function bindEvents() {
     // Search
-    els.searchInput.addEventListener('input', (e) => handleSearch(e.target.value));
+    els.searchInput.addEventListener('input', (e) => handleAutocomplete(e.target.value));
     els.searchInput.addEventListener('keydown', handleSearchKeydown);
     els.searchInput.addEventListener('focus', () => {
-        if (els.searchInput.value) handleSearch(els.searchInput.value);
+        if (els.searchInput.value) handleAutocomplete(els.searchInput.value);
     });
 
     // Close dropdown on outside click


### PR DESCRIPTION
## What changed
Renamed the duplicated `handleSearch` function (which was incorrectly calling `/api/autocomplete`) to `handleAutocomplete` in `frontend/app.js` and updated the `input` and `focus` event listeners to use the new function. 

## Why
Because JavaScript hoists function declarations, having two functions with the same name meant the second definition (autocomplete) was overwriting the first one (actual search functionality). This fix correctly separates the search behavior and the autocomplete suggestion behavior.

## How to test
1. Run the backend and open `http://localhost:8000` in your browser.
2. Type into the search bar and verify that the autocomplete dropdown correctly shows search suggestions.
3. Select an item or hit enter, and verify that the actual `/api/search` executes correctly without throwing errors or relying solely on the autocomplete endpoint.


## Checklist
- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] My code follows PEP8 style (`flake8 .`)
- [X] I have tested my changes locally
- [X] I have added/updated tests where applicable
- [X] I can explain every line of code I've written
- [X] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #179

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: FOR UNDERSTANDING CODEBASE
