### PR TITLE
fix: add api health check endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from typing import Optional
 from dotenv import load_dotenv
+from datetime import datetime
 
 load_dotenv()
 
@@ -87,6 +88,13 @@ def status():
         "build_time": models["build_time"],
     }
 
+@app.get("/api/health")
+def health_check():
+    return {
+        "status": "healthy",
+        "timestamp": datetime.utcnow().isoformat(),
+        "model_loaded": models["ready"]
+    }
 
 # ── Search (PostgreSQL FTS) ─────────────────────────────────────────
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert data["status"] == "healthy"
+    assert "timestamp" in data
+    assert isinstance(data["model_loaded"], bool)


### PR DESCRIPTION
## What changed

* Added a new `/api/health` endpoint to `backend/main.py`
* Implemented health status response with timestamp and model state
* Added API test coverage for the health endpoint

## Why

Deployment platforms and monitoring systems rely on health-check endpoints to verify server availability. The missing `/api/health` route caused deployment health checks to fail with `404 Not Found`.

## How to test

```bash id="t5k8wp"
uvicorn backend.main:app --reload
```

Open:

```text id="r6n2qy"
http://localhost:8000/api/health
```

Expected response:

```json id="v3m7cx"
{
  "status": "healthy",
  "timestamp": "...",
  "model_loaded": true
}
```

Run tests:

```bash id="u8x4zn"
python -m pytest
```

## Checklist

* [x] Added `/api/health` endpoint
* [x] Returns HTTP 200
* [x] Includes timestamp field
* [x] Includes `model_loaded` boolean
* [x] Added automated test coverage
* [x] Tested locally

## Related issue

Closes #245

## AI assistance disclosure

* [x] I used AI assistance for:

  * FastAPI endpoint implementation guidance
  * pytest test drafting
  * PR drafting
