### PR TITLE
[GSSoC'26] Add Docker Compose setup and fix backend startup issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,5 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 .agent.vscode/
+.claude
+.refact

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <div align="center">
 
 [![CI](https://github.com/leonagoel/hybrid-recommender/actions/workflows/ci.yml/badge.svg)](https://github.com/leonagoel/hybrid-recommender/actions/workflows/ci.yml)
+[![Docker Compose](https://img.shields.io/badge/Docker_Compose-ready-2496ED?style=flat-square&logo=docker&logoColor=white)](#run-with-docker-compose-recommended-for-contributors)
 [![License](https://img.shields.io/github/license/leonagoel/hybrid-recommender)](https://github.com/leonagoel/hybrid-recommender/blob/main/LICENSE)
 [![Python Version](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/)
 [![Contributors](https://img.shields.io/github/contributors/leonagoel/hybrid-recommender.svg?style=flat-square)](https://github.com/leonagoel/hybrid-recommender/graphs/contributors)
@@ -239,6 +240,58 @@ streamlit run app.py
 Upload any CSV file, click **Build Models**, then enter an item name or User ID to get recommendations directly in your browser — no database or server setup needed.
 
 ---
+
+### Run with Docker Compose (Recommended for Contributors)
+
+Docker Compose starts the full stack — backend API **and** static frontend —
+with a single command. No manual port juggling, no missing env vars.
+
+#### Prerequisites
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Compose)
+
+#### Steps
+
+**1. Copy and fill in your environment file**
+
+```bash
+cp .env.example .env
+# Edit .env with your Supabase credentials
+```
+
+**2. Start the stack**
+
+```bash
+docker-compose up --build
+```
+
+- `--build` forces a fresh image build. Omit it on subsequent runs when
+  code hasn't changed.
+
+**3. Access the app**
+
+| Service  | URL                        |
+|----------|----------------------------|
+| Frontend | http://localhost:3000       |
+| Backend  | http://localhost:8000       |
+| API docs | http://localhost:8000/docs  |
+| Health   | http://localhost:8000/health|
+
+**4. Stop the stack**
+
+```bash
+docker-compose down
+```
+
+Add `-v` to also remove named volumes if you want a completely clean state.
+
+#### Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Error: .env file not found` | Run `cp .env.example .env` and fill in credentials |
+| Backend unhealthy / frontend won't start | Check `docker-compose logs backend` |
+| Port 8000 already in use | Stop other services on 8000, or change `"8000:8000"` to `"8001:8000"` |
+| Dataset not found at runtime | Make sure `datasets/` folder exists in project root |
 
 ## 06 — API Reference
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -66,7 +66,54 @@ docker run --env-file .env -p 8000:8000 hybrid-recommender
 
 The API will be available at [http://localhost:8000](http://localhost:8000).
 
-### 7. Open the App
+### 7. Run with Docker Compose (Recommended for Contributors)
+
+Docker Compose starts the full stack — backend API **and** static frontend —
+with a single command.
+
+#### Prerequisites
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Compose)
+
+#### Steps
+
+**1. Copy and fill in your environment file**
+```bash
+cp .env.example .env
+# Edit .env with your Supabase credentials
+```
+
+**2. Start the full stack**
+```bash
+docker-compose up --build
+```
+`--build` forces a fresh image build. Omit it on subsequent runs when code hasn't changed.
+
+**3. Access the app**
+
+| Service  | URL                         |
+|----------|-----------------------------|
+| Frontend | http://localhost:3000        |
+| Backend  | http://localhost:8000        |
+| API Docs | http://localhost:8000/docs   |
+| Health   | http://localhost:8000/health |
+
+**4. Stop the stack**
+```bash
+docker-compose down
+```
+
+#### Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `.env file not found` | Run `cp .env.example .env` and fill in credentials |
+| Backend unhealthy | Check `docker-compose logs backend` |
+| Port 8000 already in use | Change `"8000:8000"` to `"8001:8000"` in `docker-compose.yml` |
+| Dataset not found | Make sure `datasets/` folder exists in project root |
+
+---
+
+### 8. Open the App
 Navigate to: [http://localhost:8000](http://localhost:8000)
 
 ## Architecture

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,22 +41,34 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from db import get_supabase, get_supabase_admin
-from data_adapter import adapt_data, read_file
-from nlp_engine import batch_analyze, aggregate_sentiment_by_item
-from content_model import ContentRecommender
-from collaborative_model import CollaborativeRecommender
-from hybrid_model import HybridRecommender
 from celery.result import AsyncResult
 from celery_app import celery_app
 from tasks import compute_recommendations
-from ab_testing import DEFAULT_EXPERIMENT_ID, run_recommendation_experiment
+
+
+# backend/main.py — corrected imports
+from src.data.db import get_supabase, get_supabase_admin
+from src.data.data_adapter import adapt_data, read_file
+from src.model.nlp_engine import batch_analyze, aggregate_sentiment_by_item
+from src.model.content_model import ContentRecommender
+from src.model.collaborative_model import CollaborativeRecommender
+from src.model.hybrid_model import HybridRecommender
+from src.evaluation.ab_testing import DEFAULT_EXPERIMENT_ID, run_recommendation_experiment
+# from src.evaluation.evaluation import run_evaluation
 
 from functools import lru_cache
 from datetime import datetime, timedelta
 
 # ── App ──────────────────────────────────────────────────────────────
 app = FastAPI(title="Hybrid Recommender API", version="3.0")
+
+@app.get("/health", tags=["meta"])
+async def health_check():
+    """
+    Liveness probe used by Docker Compose health check.
+    Returns 200 when the server is ready to accept requests.
+    """
+    return JSONResponse({"status": "ok"})
 
 RESPONSE_TIME_HEADER = "X-Response-Time-ms"
 DEFAULT_SLOW_RESPONSE_THRESHOLD_MS = 1000.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+services:
+  # ── Backend ──────────────────────────────────────────────────────────────
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hybridrec-backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./datasets:/app/datasets:ro   # mount datasets/ read-only
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - hybridrec
+
+  # ── Frontend ─────────────────────────────────────────────────────────────
+  frontend:
+    image: nginx:alpine
+    container_name: hybridrec-frontend
+    ports:
+      - "3000:80"
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - hybridrec
+
+networks:
+  hybridrec:
+    driver: bridge

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scipy>=1.11.0
 streamlit>=1.28.0
 celery>=5.3.6
 redis>=5.0.1
+sentence-transformers>=2.2.0


### PR DESCRIPTION
## What changed

* Added Docker Compose setup instructions to `README.md` and `SETUP.md`
* Added a `/health` endpoint for backend health checks
* Fixed incorrect backend import paths in `backend/main.py`
* Added missing dependency:

  * `sentence-transformers>=2.2.0`
* Added `.claude` and `.refact` to `.gitignore` to avoid tracking local workspace files

## Why

While testing the project setup locally and through Docker Compose, the backend container failed to start because of incorrect imports and a missing runtime dependency. This PR fixes those startup issues and adds a documented Docker Compose workflow so contributors can run the full stack more easily.

## How to test

```bash id="t3"
# Clone the repository
git clone <repo-url>
cd hybrid-recommender

# Create environment file
cp .env.example .env

# Start services
docker compose up --build
```

After startup:

* Frontend: http://localhost:3000/
* Backend: http://localhost:8000/
* API Docs: http://localhost:8000/docs
* Health Check: http://localhost:8000/health

## Screenshots (if UI change)

N/A

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md)
* [x] My code follows PEP8 style (`flake8 .`)
* [x] I have tested my changes locally
* [ ] I have added/updated tests where applicable
* [x] I can explain every line of code I've written
* [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue

Closes #<!-- issue number -->

## AI assistance disclosure

* [ ] I did not use AI assistance for this PR
* [x] I used AI assistance for debugging setup/runtime issues and improving documentation clarity.