### PR TITLE
Add automatic cleanup for expired response cache entries

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -180,9 +180,20 @@ def _get_cached_response(key: str) -> Any | None:
 
     logger.info("cache_hit", extra={"cache_key": key})
     return value
+    
+def _cleanup_expired_cache():
+    now = time.time()
+    expired_keys = [
+        key for key, (expires_at, _) in _response_cache.items()
+        if expires_at <= now
+    ]
+
+    for key in expired_keys:
+        _response_cache.pop(key, None)
 
 
 def _set_cached_response(key: str, value: Any) -> None:
+    _cleanup_expired_cache()
     _response_cache[key] = (time.time() + CACHE_TTL_SECONDS, value)
 
 


### PR DESCRIPTION
What changed
Added automatic cleanup for expired entries in the in-memory response cache. A helper function _cleanup_expired_cache() removes expired cache items whenever new cache entries are written.
Why
The existing cache stores expired entries indefinitely until they are accessed again. This can lead to unnecessary memory usage over time in high-traffic scenarios. This change ensures expired entries are cleaned proactively.
How to test
Bash
# Run the FastAPI server
uvicorn main:app --reload
Then:
Hit any cached endpoint (like /api/search)
Wait for cache TTL to expire (if configured)
Trigger requests again
Verify memory does not grow with stale cache entries
Optional debug check:
Add temporary logs inside _cleanup_expired_cache() to confirm cleanup execution
Screenshots (if UI change)
Not applicable (backend change only)
Checklist
 I have read the CONTRIBUTING.md
 My code follows PEP8 style
 I have tested my changes locally
 I have added/updated tests where applicable
 I can explain every line of code I've written
I have NOT used AI-generated code without understanding and attributing it
Related issue
Closes #273 
AI assistance disclosure
 I used AI assistance for: helping structure the fix and PR description, but I understand the code fully and implemented it myself