### PR TITLE
Fix Windows setup documentation and Streamlit app path

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -52,6 +52,22 @@ python scripts/seed_mock_data.py --users 50 --purchases 2000  # Custom amounts
 ```bash
 python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
 ```
+## Windows Local Setup (Recommended)
+
+If you encounter dependency issues on Windows, it is recommended to create a clean conda environment.
+
+### Create Environment
+
+```bash
+conda create -n hybridrec python=3.10 -y
+conda activate hybridrec
+
+pip install -r requirements.txt
+pip install sentence-transformers
+
+## Run your streamlit app easy way to run the app 
+$env:PYTHONPATH="."
+streamlit run src/api/app.py
 
 ### 6. Run with Docker
 Build the container image from the repository root:
@@ -101,4 +117,4 @@ hybrid-recommender/
 - **Recommendations:** Hybrid (Content + Collaborative + Sentiment)
 - **Upload:** CSV and JSON format support
 - **UI:** Amazon-like modern design with animations
-- **Streamlit UI:** Upload a CSV locally, build models, and get recommendations — no Supabase or server setup needed (`streamlit run app.py`)
+- **Streamlit UI:** Upload a CSV locally, build models, and get recommendations — no Supabase or server setup needed (`streamlit run src/api/app.py`)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -68,7 +68,7 @@ weights = {
 
 total_weight = sum(weights.values())
 
-st.markdown("###Live Normalized Weight Preview")
+st.markdown("###Live Normalized Weight Preview")git checkout -b fix-windows-setup-docs
 
 if total_weight <= 0:
     st.warning("All weights are set to zero. Please increase at least one weight to see the normalized distribution.")


### PR DESCRIPTION
## What changed

- Fixed outdated Streamlit run command in `SETUP.md`
- Added Windows local setup instructions
- Added conda environment setup recommendation
- Added `sentence-transformers` installation step
- Added `PYTHONPATH` fix for Streamlit imports
- Updated Streamlit app path to `src/api/app.py`
- Fixed markdown formatting issue in app UI

## Why

While setting up the project locally on Windows, I encountered multiple setup issues such as:

- incorrect Streamlit path
- missing dependencies
- import path issues
- Windows environment compatibility problems

These changes improve onboarding and setup experience for contributors using Windows.

## How to test

1. Create environment:
```bash
conda create -n hybridrec python=3.10 -y
conda activate hybridrec