### PR TITLE
Persist weight slider values using sessionStorage

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -571,9 +571,28 @@ async function handleWeightChange() {
     const b = parseInt(els.weightBeta.value);
     const g = parseInt(els.weightGamma.value);
 
+    // Save values to sessionStorage
+    sessionStorage.setItem('alpha', a);
+    sessionStorage.setItem('beta', b);
+    sessionStorage.setItem('gamma', g);
+
     try {
-        await API.put('/api/weights', { alpha: a / 100, beta: b / 100, gamma: g / 100 });
+        await API.put('/api/weights', {
+            alpha: a / 100,
+            beta: b / 100,
+            gamma: g / 100
+        });
     } catch {}
+}
+
+function loadSavedWeights() {
+    const alpha = sessionStorage.getItem('alpha') || 33;
+    const beta = sessionStorage.getItem('beta') || 33;
+    const gamma = sessionStorage.getItem('gamma') || 33;
+
+    els.weightAlpha.value = alpha;
+    els.weightBeta.value = beta;
+    els.weightGamma.value = gamma;
 }
 
 // ── Event Listeners ─────────────────────────────────────────────────
@@ -643,6 +662,7 @@ document.head.appendChild(spinStyle);
 // ── Init ────────────────────────────────────────────────────────────
 async function init() {
     bindEvents();
+    loadSavedWeights();
     initTypeToSearch();
 
     // Initialize Supabase client from backend config (no hardcoded keys)


### PR DESCRIPTION
## What changed

* Added persistence for alpha, beta, and gamma weight sliders using `sessionStorage`
* Slider values now restore automatically after page refresh
* Added default fallback values when no stored values exist

## Why

Previously, refreshing the page reset all weight sliders back to their default values, causing users to lose their tuning preferences. This update improves UX by preserving slider state across refreshes.

## How to test

```bash id="n9s8yt"
pip install -r requirements.txt
python app.py
```

1. Open the app
2. Adjust alpha, beta, and gamma sliders
3. Refresh the page
4. Verify all slider values remain unchanged

Expected:

* Slider values persist correctly after refresh
* Works for all three sliders



## Checklist

* [x] I have read the [[CONTRIBUTING.md]
* [x] My code follows PEP8 style (`flake8 .`)
* [x] I have tested my changes locally
* [ ] I have added/updated tests where applicable
* [x] I can explain every line of code I've written
* [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue

Closes #219 

## AI assistance disclosure

* [x] I used AI assistance for:

  * Understanding session Storage persistence
  * Implementing slider state restoration
  * Drafting the PR description