### PR TITLE
fix: bound search query parsing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,7 @@ RESPONSE_TIME_HEADER = "X-Response-Time-ms"
 DEFAULT_SLOW_RESPONSE_THRESHOLD_MS = 1000.0
 CACHE_TTL_SECONDS = 300
 CACHE_CONTROL_VALUE = f"public, max-age={CACHE_TTL_SECONDS}"
+MAX_SEARCH_QUERY_LENGTH = 120
 _response_cache: dict = {}
 
 
@@ -87,6 +88,25 @@ def _set_cached_response(key: str, value: Any) -> None:
 
 def _clear_response_cache() -> None:
     _response_cache.clear()
+
+
+def _normalize_search_query(query: str) -> str:
+    normalized = " ".join((query or "").split())
+    if len(normalized) > MAX_SEARCH_QUERY_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Search query must be {MAX_SEARCH_QUERY_LENGTH} characters or fewer.",
+        )
+    return normalized
+
+
+def _escape_like_pattern(value: str) -> str:
+    return (
+        value
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
 
 
 def _set_cache_headers(response: Response, status: str) -> None:
@@ -339,22 +359,24 @@ def search_items(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
-    cache_key = _cache_key("search", q, limit, offset)
+    query = _normalize_search_query(q)
+    cache_key = _cache_key("search", query, limit, offset)
     cached = _get_cached_response(cache_key)
     if cached is not None:
         _set_cache_headers(response, "HIT")
         return cached
 
     sb = get_supabase()
-    if q.strip():
+    if query:
         try:
             result = sb.rpc('search_products', {
-                'query_text': q.strip(), 'match_count': limit, 'offset_val': offset,
+                'query_text': query, 'match_count': limit, 'offset_val': offset,
             }).execute()
             products = result.data or []
         except Exception as e:
-            logger.warning("FTS failed for '%s': %s", q.strip(), e)
-            result = sb.table('products').select('id, title, description, category, rating, avg_sentiment, review_count').ilike('title', f'%{q.strip()}%').order('rating', desc=True).limit(limit).execute()
+            logger.warning("FTS failed for '%s': %s", query, e)
+            escaped_query = _escape_like_pattern(query)
+            result = sb.table('products').select('id, title, description, category, rating, avg_sentiment, review_count').ilike('title', f'%{escaped_query}%').order('rating', desc=True).limit(limit).execute()
             products = result.data or []
             for p in products:
                 p['rank'] = 0.0
@@ -372,7 +394,7 @@ def search_items(
             'review_count': p.get('review_count', 0), 'rank': p.get('rank', 0.0),
         })
 
-    payload = {"results": results, "total": len(results), "query": q, "is_fallback": not q.strip()}
+    payload = {"results": results, "total": len(results), "query": query, "is_fallback": not query}
     _set_cached_response(cache_key, payload)
     _set_cache_headers(response, "MISS")
     return payload
@@ -385,11 +407,12 @@ def autocomplete_products(
     limit: int = Query(5, ge=1, le=10),
 ):
     sb = get_supabase()
-    query = q.strip()
+    query = _normalize_search_query(q)
     if not query:
         return {"suggestions": []}
     try:
-        result = sb.table('products').select('title').ilike('title', f'%{query}%').limit(limit).execute()
+        escaped_query = _escape_like_pattern(query)
+        result = sb.table('products').select('title').ilike('title', f'%{escaped_query}%').limit(limit).execute()
         suggestions = []
         seen = set()
         for item in result.data or []:

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -132,3 +132,38 @@ def test_search_query_falls_back_to_title_match_when_rpc_fails(monkeypatch):
     assert payload["results"][0]["title"] == "Laptop Stand"
     assert payload["results"][0]["rank"] == 0.0
     assert ("ilike", ("title", "%stand%"), {}) in fake_supabase.table_query.calls
+
+
+def test_search_rejects_oversized_query(monkeypatch):
+    fake_supabase = FakeSupabase()
+    monkeypatch.setattr(main, "get_supabase", lambda: fake_supabase)
+    client = TestClient(main.app)
+
+    response = client.get("/api/search", params={"q": "a" * (main.MAX_SEARCH_QUERY_LENGTH + 1)})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Search query must be 120 characters or fewer."
+    assert fake_supabase.rpc_calls == []
+
+
+def test_search_normalizes_query_before_cache_and_rpc(monkeypatch):
+    fake_supabase = FakeSupabase(rpc_data=PRODUCTS[:1])
+    monkeypatch.setattr(main, "get_supabase", lambda: fake_supabase)
+    client = TestClient(main.app)
+
+    response = client.get("/api/search", params={"q": "  wireless   headphones  "})
+
+    assert response.status_code == 200
+    assert response.json()["query"] == "wireless headphones"
+    assert fake_supabase.rpc_calls[0][1]["query_text"] == "wireless headphones"
+
+
+def test_search_fallback_escapes_like_wildcards(monkeypatch):
+    fake_supabase = FakeSupabase(table_data=PRODUCTS[1:], rpc_error=RuntimeError("rpc unavailable"))
+    monkeypatch.setattr(main, "get_supabase", lambda: fake_supabase)
+    client = TestClient(main.app)
+
+    response = client.get("/api/search", params={"q": r"50%_off\sale"})
+
+    assert response.status_code == 200
+    assert ("ilike", ("title", r"%50\%\_off\\sale%"), {}) in fake_supabase.table_query.calls


### PR DESCRIPTION
## What changed
- Normalized search and autocomplete queries before RPC, cache, and fallback matching.
- Added a maximum search query length guard.
- Escaped SQL LIKE wildcard characters for fallback title matching.
- Removed unresolved conflict markers from `content_model.py` so backend modules compile.
- Added regression tests for oversized, normalized, and wildcard-heavy queries.

## Why
Unbounded or wildcard-heavy search inputs can create expensive broad matching behavior and denial-of-service risk. Search input should be bounded and treated as literal text in fallback matching.

## How to test
- `python -m py_compile backend/main.py src/model/content_model.py tests/test_search_api.py`
- `git diff --check`

Note: direct pytest collection is currently blocked by the repo missing `sentence_transformers` in `requirements.txt` while importing `src/model/content_model.py`.

Fixes #324