### PR TITLE
fix: reject extra fields on write models

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Any, Optional
 from dotenv import load_dotenv
 
@@ -178,12 +178,16 @@ models = {
 
 
 class WeightsUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     alpha: float = 0.4
     beta: float = 0.35
     gamma: float = 0.25
 
 
 class PurchaseCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     user_id: str
     product_id: int
     rating: float = 0.0
@@ -191,12 +195,16 @@ class PurchaseCreate(BaseModel):
 
 
 class FeedbackCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     user_id: str
     item: str
     feedback: str
 
 
 class RealtimeRecommendationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     item_title: str
     top_n: int = 10
     explain: bool = False

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)

--- a/tests/test_request_model_extras.py
+++ b/tests/test_request_model_extras.py
@@ -1,0 +1,30 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.main import FeedbackCreate, PurchaseCreate, RealtimeRecommendationRequest, WeightsUpdate
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (PurchaseCreate, {"user_id": "u1", "product_id": 1, "role": "admin"}),
+        (FeedbackCreate, {"user_id": "u1", "item": "Alpha", "feedback": "ok", "is_admin": True}),
+        (WeightsUpdate, {"alpha": 0.5, "beta": 0.3, "gamma": 0.2, "owner": "attacker"}),
+        (RealtimeRecommendationRequest, {"item_title": "Alpha", "top_n": 5, "user_id": "victim"}),
+    ],
+)
+def test_write_models_reject_extra_fields(model, payload):
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_purchase_model_accepts_expected_fields_only():
+    purchase = PurchaseCreate.model_validate({
+        "user_id": "u1",
+        "product_id": 42,
+        "rating": 4.5,
+        "review_text": "useful",
+    })
+
+    assert purchase.user_id == "u1"
+    assert purchase.product_id == 42


### PR DESCRIPTION
## What changed
- Configured write request models to reject unexpected fields.
- Covered purchases, feedback, weights, and realtime recommendation payloads.
- Added regression tests for rejected attacker-controlled extra fields.
- Removed unresolved conflict markers from `content_model.py` so backend modules compile.

## Why
Silently accepting extra request fields can enable mass-assignment style bugs where client-supplied keys influence internal state now or after future refactors.

## How to test
- `python -m py_compile backend/main.py src/model/content_model.py tests/test_request_model_extras.py`
- `git diff --check`

Note: direct pytest collection is currently blocked by the repo missing `sentence_transformers` in `requirements.txt` while importing `src/model/content_model.py`.

Fixes #322