### PR TITLE
fix: harden dataset upload validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,7 @@ RESPONSE_TIME_HEADER = "X-Response-Time-ms"
 DEFAULT_SLOW_RESPONSE_THRESHOLD_MS = 1000.0
 CACHE_TTL_SECONDS = 300
 CACHE_CONTROL_VALUE = f"public, max-age={CACHE_TTL_SECONDS}"
+MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", str(5 * 1024 * 1024)))
 _response_cache: dict = {}
 
 
@@ -92,6 +93,27 @@ def _clear_response_cache() -> None:
 def _set_cache_headers(response: Response, status: str) -> None:
     response.headers["Cache-Control"] = CACHE_CONTROL_VALUE
     response.headers["X-Cache"] = status
+
+
+def _validate_upload_bytes(filename: str, ext: str, contents: bytes) -> None:
+    if not contents:
+        raise HTTPException(400, "Uploaded file is empty.")
+    if len(contents) > MAX_UPLOAD_BYTES:
+        raise HTTPException(413, f"Uploaded file exceeds {MAX_UPLOAD_BYTES} bytes.")
+    if b"\x00" in contents[:4096]:
+        raise HTTPException(400, "Uploaded file appears to be binary.")
+
+    sample = contents[:4096].lstrip()
+    lowered_name = filename.lower()
+    if ext == ".json":
+        if not sample.startswith((b"{", b"[")):
+            raise HTTPException(400, "JSON uploads must contain JSON content.")
+    elif ext == ".csv":
+        lowered_sample = sample[:128].lower()
+        if lowered_sample.startswith((b"{", b"[", b"<!doctype", b"<html", b"<?xml")):
+            raise HTTPException(400, "CSV uploads must contain CSV content.")
+        if not lowered_name.endswith(".csv"):
+            raise HTTPException(400, "CSV uploads must use a .csv filename.")
 
 
 # CORS
@@ -412,6 +434,7 @@ async def upload_dataset(file: UploadFile = File(...)):
         raise HTTPException(400, "Only CSV and JSON files are supported.")
     try:
         contents = await file.read()
+        _validate_upload_bytes(filename, ext, contents)
         buf = io.BytesIO(contents)
         raw_df = read_file(buf, file_format=ext.replace('.', ''))
         adapted_df, meta = adapt_data(raw_df)

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)

--- a/tests/test_upload_validation.py
+++ b/tests/test_upload_validation.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.main import _validate_upload_bytes
+
+
+def test_upload_validation_rejects_empty_files():
+    with pytest.raises(HTTPException) as exc:
+        _validate_upload_bytes("products.csv", ".csv", b"")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Uploaded file is empty."
+
+
+def test_upload_validation_rejects_binary_files():
+    with pytest.raises(HTTPException) as exc:
+        _validate_upload_bytes("products.csv", ".csv", b"title\x00rating\nA,5")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Uploaded file appears to be binary."
+
+
+def test_upload_validation_rejects_json_named_as_csv():
+    with pytest.raises(HTTPException) as exc:
+        _validate_upload_bytes("products.csv", ".csv", b'{"title":"Alpha"}')
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "CSV uploads must contain CSV content."
+
+
+def test_upload_validation_rejects_csv_named_as_json():
+    with pytest.raises(HTTPException) as exc:
+        _validate_upload_bytes("products.json", ".json", b"title,rating\nAlpha,5")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "JSON uploads must contain JSON content."
+
+
+def test_upload_validation_accepts_csv_and_json_shapes():
+    _validate_upload_bytes("products.csv", ".csv", b"title,rating\nAlpha,5")
+    _validate_upload_bytes("products.json", ".json", b'[{"title":"Alpha"}]')


### PR DESCRIPTION
## What changed
- Added upload validation for empty, oversized, binary, and content/extension-mismatched files.
- Added an env-configurable `MAX_UPLOAD_BYTES` limit.
- Added regression tests for rejected and accepted upload shapes.
- Removed unresolved conflict markers from `content_model.py` so backend modules compile.

## Why
The upload endpoint accepted supported extensions and then parsed the entire file directly. Early validation reduces unsafe upload handling, resource abuse, and confusing parser failures.

## How to test
- `python -m py_compile backend/main.py src/model/content_model.py tests/test_upload_validation.py`
- `git diff --check`

Note: direct pytest collection is currently blocked by the repo missing `sentence_transformers` in `requirements.txt` while importing `src/model/content_model.py`.

Fixes #312