### PR TITLE
fix: protect admin dashboard with token auth

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ import io
 import time
 import logging
 import math
+import secrets
 from collections import deque, Counter
 from threading import Lock
 from datetime import datetime, timezone
@@ -92,6 +93,28 @@ def _clear_response_cache() -> None:
 def _set_cache_headers(response: Response, status: str) -> None:
     response.headers["Cache-Control"] = CACHE_CONTROL_VALUE
     response.headers["X-Cache"] = status
+
+
+def _extract_bearer_token(value: str | None) -> str:
+    if not value:
+        return ""
+    scheme, _, token = value.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def _require_admin_access(request: Request) -> None:
+    expected_token = os.environ.get("ADMIN_API_TOKEN", "").strip()
+    if not expected_token:
+        return
+
+    provided_token = (
+        request.headers.get("x-admin-token", "").strip()
+        or _extract_bearer_token(request.headers.get("authorization"))
+    )
+    if not provided_token or not secrets.compare_digest(provided_token, expected_token):
+        raise HTTPException(status_code=401, detail="Admin token required.")
 
 
 # CORS
@@ -240,7 +263,8 @@ def status():
 
 # ── Dashboard ─────────────────────────────────────────────────────────
 @app.get("/api/dashboard")
-def dashboard():
+def dashboard(request: Request):
+    _require_admin_access(request)
     sb = get_supabase()
     try:
         product_count = sb.table('products').select('id', count='exact').limit(0).execute().count or 0

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)

--- a/tests/test_admin_dashboard_auth.py
+++ b/tests/test_admin_dashboard_auth.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.main import _extract_bearer_token, _require_admin_access
+
+
+class FakeRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+def test_extract_bearer_token_accepts_bearer_only():
+    assert _extract_bearer_token("Bearer secret-token") == "secret-token"
+    assert _extract_bearer_token("Basic secret-token") == ""
+    assert _extract_bearer_token(None) == ""
+
+
+def test_admin_access_allows_when_token_not_configured(monkeypatch):
+    monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
+
+    _require_admin_access(FakeRequest())
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"x-admin-token": "expected-token"},
+        {"authorization": "Bearer expected-token"},
+    ],
+)
+def test_admin_access_accepts_configured_token(monkeypatch, headers):
+    monkeypatch.setenv("ADMIN_API_TOKEN", "expected-token")
+
+    _require_admin_access(FakeRequest(headers))
+
+
+def test_admin_access_rejects_missing_or_invalid_token(monkeypatch):
+    monkeypatch.setenv("ADMIN_API_TOKEN", "expected-token")
+
+    with pytest.raises(HTTPException) as exc:
+        _require_admin_access(FakeRequest({"x-admin-token": "wrong-token"}))
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Admin token required."


### PR DESCRIPTION
## What changed
- Added optional `ADMIN_API_TOKEN` protection to the dashboard analytics endpoint.
- Accepted credentials through `X-Admin-Token` or `Authorization: Bearer ...`.
- Used `secrets.compare_digest` for token comparison.
- Added regression tests for missing, accepted, and rejected tokens.
- Removed unresolved conflict markers from `content_model.py` so backend modules compile.

## Why
The dashboard exposes admin-style analytics. Deployments that configure an admin token should be able to protect that endpoint without changing route behavior for local/demo setups.

## How to test
- `python -m py_compile backend/main.py src/model/content_model.py tests/test_admin_dashboard_auth.py`
- `git diff --check`

Note: direct pytest collection is currently blocked by the repo missing `sentence_transformers` in `requirements.txt` while importing `src/model/content_model.py`.

Fixes #318