### PR TITLE
fix: make CORS origins configurable via CORS_ORIGINS env var (#235)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ SUPABASE_ANON_KEY=your-anon-key-here
 SUPABASE_SERVICE_KEY=your-service-role-key-here
 
 REDIS_URL=redis://localhost:6379/0
+
+# CORS allowed origins (comma-separated, no spaces)
+CORS_ORIGINS=http://localhost:8000,http://127.0.0.1:8000,http://localhost:5500,http://localhost:3000,http://localhost:5173

--- a/backend/main.py
+++ b/backend/main.py
@@ -95,10 +95,13 @@ def _set_cache_headers(response: Response, status: str) -> None:
 
 
 # CORS
-allowed_origins = os.environ.get("CORS_ORIGINS", "*").split(",")
+allowed_origins_env = os.environ.get("CORS_ORIGINS", "http://localhost:8000,http://127.0.0.1:8000")
+allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",")]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## What changed
- Replaced hardcoded `allow_origins=["*"]` with configurable origins from environment variable `CORS_ORIGINS`.
- Added `allow_credentials=True` to support authenticated requests.
- Updated `.env.example` to include `CORS_ORIGINS` with common development ports (5500, 3000, 5173).

## Why
Closes #235 – When frontend is served on a different port (e.g., Live Server on 5500), API calls failed with CORS error because the backend did not explicitly allow that origin. Now developers can configure allowed origins via `.env` without modifying code.

## How to test
```bash
# Set up backend with custom CORS origin
cd backend
cp .env.example .env
# Edit .env and set CORS_ORIGINS=http://localhost:5500 (or your frontend port)
uvicorn main:app --reload

# Serve frontend on a different port (e.g., using VS Code Live Server on port 5500)
# Make any API call – no CORS error should appear.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #235 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: code structure
