### PR TITLE
fix : resolved committed git merge conflict in content_model.py

### DIFF
--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)


### PR DESCRIPTION
## What changed
Resolved committed Git merge conflict markers (`<<<<<<< HEAD`, `=======`, and `>>>>>>>`) inside `src/model/content_model.py` that were blocking Python imports.

## Why
The presence of conflict markers resulted in syntax and indentation errors, rendering the content model module completely unimportable and failing the entire test collection suite.

## How to test
Run pytest on the content-based test suite locally:
```bash
.venv/bin/pytest tests/test_content_based.py
```

## Screenshots (if UI change)
N/A (Backend changes)

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #364

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
