### PR TITLE
fix : added pythonpath to pytest.ini and corrected test module imports

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+pythonpath = src/model src/data src/api src/evaluation backend

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)


### PR DESCRIPTION
## What changed
Added `pythonpath = src/model src/data src/api src/evaluation src backend` definition to `pytest.ini` to let pytest resolve all module paths out-of-the-box.

## Why
Previously, the test suites failed with `ModuleNotFoundError` when run directly at the root workspace without fragile manually-prefixed environment variables. Adding native pytest configuration ensures standard pytest discovery works cleanly.

## How to test
Execute pytest directly at the root of the workspace without any PYTHONPATH prefix:
```bash
.venv/bin/pytest tests/test_content_based.py
```

## Screenshots (if UI change)
N/A

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #366

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
