### PR TITLE
fix : prevented SVD crash in CollaborativeRecommender on ultra-sparse/small matrices

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+pythonpath = src/model src/data src/api src/evaluation backend

--- a/src/model/collaborative_model.py
+++ b/src/model/collaborative_model.py
@@ -57,18 +57,23 @@ class CollaborativeRecommender:
         min_dim = min(self.user_item_sparse.shape)
         density = self.user_item_sparse.nnz / (n_users * n_items) if (n_users * n_items) > 0 else 0
 
-        if density < 0.001:
-            n_components = min(20, min_dim - 1)
-        elif density < 0.01:
-            n_components = min(30, min_dim - 1)
+        if min_dim <= 1:
+            self.svd = None
+            self.user_factors = np.ones((n_users, 1))
+            self.item_factors = np.ones((1, n_items))
         else:
-            n_components = min(n_factors, min_dim - 1)
+            if density < 0.001:
+                n_components = min(20, min_dim - 1)
+            elif density < 0.01:
+                n_components = min(30, min_dim - 1)
+            else:
+                n_components = min(n_factors, min_dim - 1)
 
-        n_components = max(1, n_components)
+            n_components = max(1, n_components)
 
-        self.svd = TruncatedSVD(n_components=n_components, random_state=42)
-        self.user_factors = self.svd.fit_transform(self.user_item_sparse)
-        self.item_factors = self.svd.components_
+            self.svd = TruncatedSVD(n_components=n_components, random_state=42)
+            self.user_factors = self.svd.fit_transform(self.user_item_sparse)
+            self.item_factors = self.svd.components_
 
     def recommend(self, title, top_n=10):
         """

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)

--- a/tests/test_collaborative.py
+++ b/tests/test_collaborative.py
@@ -59,3 +59,19 @@ def test_cold_start_user():
     results = model.predict_for_user(999)
 
     assert results == []
+
+
+def test_extreme_sparse_matrix():
+    df = pd.DataFrame(
+        {
+            "user_id": [1],
+            "title": ["Naruto"],
+            "rating": [5],
+        }
+    )
+
+    model = CollaborativeRecommender(df)
+    assert model.svd is None
+    assert model.user_factors.shape == (1, 1)
+    assert model.item_factors.shape == (1, 1)
+    assert model.predict_rating(1, "Naruto") == 1.0


### PR DESCRIPTION
## What changed
Introduced active dimension boundary check logic and a fallback bypass to collaborative recommender model (`CollaborativeRecommender.fit`). If the rating matrix dimensions are ultra-sparse or very small (`min_dim <= 1`), we bypass TruncatedSVD calculation gracefully.

## Why
When testing with small datasets (such as cold start scenarios or single-entry datasets), the collaborative recommender's `TruncatedSVD` crashed with a `ValueError` since `n_components` was greater than the rank of the matrix.

## How to test
Run the collaborative recommender unit test suite which includes the sparse matrix regression test:
```bash
.venv/bin/pytest tests/test_collaborative.py
```

## Screenshots (if UI change)
N/A

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #368

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
