### PR TITLE
fix: dynamically execute VADER sentiment analysis in evaluation pipeline if missing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+pythonpath = src/model src/data src/api src/evaluation src backend

--- a/src/evaluation/evaluation.py
+++ b/src/evaluation/evaluation.py
@@ -213,6 +213,12 @@ def run_evaluation(
 
     df = df.dropna(subset=["title"]).reset_index(drop=True)
 
+    # --- auto-analyze sentiment if missing ---
+    if "sentiment_score" not in df.columns:
+        from nlp_engine import batch_analyze
+        text_col = "description" if "description" in df.columns else ("review_text" if "review_text" in df.columns else "title")
+        df = batch_analyze(df, text_col=text_col)
+
     # --- build/load matrices ---
     # Try to load pre-built matrices from disk; fall back to building on-the-fly
     tfidf_matrix = _load_or_build_tfidf(df)

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)


### PR DESCRIPTION
Closes #384.

Automates on-the-fly sentiment calculation inside `run_evaluation` if the sentiment metadata column is not already present, ensuring full calculation of baseline metrics.