### PR TITLE
fix: correct sorting logic in sentiment evaluation baseline recommendation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+pythonpath = src/model src/data src/api src/evaluation src backend

--- a/src/evaluation/evaluation.py
+++ b/src/evaluation/evaluation.py
@@ -115,11 +115,12 @@ def _get_sentiment_recs(title: str, df: pd.DataFrame, k: int) -> list[str]:
     except IndexError:
         return []
 
-    item_sentiment = df.at[idx, "sentiment_score"] if "sentiment_score" in df.columns else 0.0
     df_copy = df.copy()
-    df_copy["_sent_diff"] = (df_copy.get("sentiment_score", 0) - item_sentiment).abs()
+    if "sentiment_score" not in df_copy.columns:
+        df_copy["sentiment_score"] = 0.0
+
     df_copy = df_copy.drop(index=idx, errors="ignore")
-    top = df_copy.nsmallest(k, "_sent_diff")
+    top = df_copy.sort_values(by="sentiment_score", ascending=False).head(k)
     return top["title"].tolist()
 
 

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -32,11 +32,7 @@ class ContentRecommender:
         Returns list of dicts: [{ 'title', 'content_score' }, ...]
         """
         if title.lower() not in self._title_to_idx:
-<<<<<<< HEAD:src/model/content_model.py
             return []
-=======
-          return []
->>>>>>> 26389e7 (feat: add multi-language search support for Hindi and English):content_model.py
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)


### PR DESCRIPTION
Closes #386.

Corrects the sentiment recommender to sort strictly by descending VADER sentiment scores as specified by baseline evaluation metrics.