### PR TITLE
fix : removed duplicate imports in test_content_based.py

### DIFF
--- a/tests/test_content_based.py
+++ b/tests/test_content_based.py
@@ -50,60 +50,6 @@ def content_model(sample_item_df):
     return ContentRecommender(sample_item_df)
 
 
-"""
-Unit tests for Content-Based Recommender
-Run with: pytest tests/ -v
-"""
-import pytest
-import pandas as pd
-import numpy as np
-import sys
-import os
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-from src.model.content_model import ContentRecommender
-
-
-# ─── Fixtures ────────────────────────────────────────────────────────────────
-
-@pytest.fixture
-def sample_item_df():
-    """Sample DataFrame for testing ContentRecommender."""
-    return pd.DataFrame({
-        'title': [
-            'Harry Potter',
-            'Lord of the Rings',
-            'The Hobbit',
-            'Game of Thrones',
-            'Dune'
-        ],
-        'description': [
-            'A young wizard discovers his magical heritage',
-            'A fellowship embarks on a quest to destroy a ring',
-            'A hobbit goes on an unexpected journey',
-            'Noble families fight for control of the Iron Throne',
-            'A desert planet holds the most valuable resource',
-        ],
-        'category': [
-            'Fantasy', 'Fantasy', 'Fantasy', 'Fantasy', 'SciFi'
-        ],
-        'combined': [
-            'Harry Potter A young wizard discovers his magical heritage Fantasy',
-            'Lord of the Rings A fellowship embarks on a quest Fantasy',
-            'The Hobbit A hobbit goes on an unexpected journey Fantasy',
-            'Game of Thrones Noble families fight for the Iron Throne Fantasy',
-            'Dune A desert planet holds the most valuable resource SciFi',
-        ],
-    })
-
-
-@pytest.fixture
-def content_model(sample_item_df):
-    """Create ContentRecommender instance with sample data."""
-    return ContentRecommender(sample_item_df)
-
-
 # ─── Tests ───────────────────────────────────────────────────────────────────
 
 class TestContentRecommender:


### PR DESCRIPTION
Closes #415.

Summary of What Has Been Done:
Removed duplicate imports, docstring, and fixture definitions from tests/test_content_based.py. The file had a duplicate block of code at lines 53-104 that was identical to lines 1-52.

Changes Made:
- Removed duplicate module imports (pytest, pandas, numpy, sys, os)
- Removed duplicate ContentRecommender import
- Removed duplicate docstring
- Removed duplicate fixture definitions (sample_item_df and content_model)
- File reduced from 179 lines to 125 lines (54 lines removed)

Impact it Made:
- Clean code without redundancy
- Easier maintenance
- Slightly faster module loading