### PR TITLE
fix : added input validation for HybridRecommender weights

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -80,6 +80,11 @@ class HybridRecommender:
 
     def set_weights(self, alpha, beta, gamma):
         """Update the scoring weights. Normalized to sum to 1."""
+        import math
+        if any(math.isnan(w) for w in [alpha, beta, gamma]):
+            raise ValueError("Weights must be finite numbers")
+        if any(w < 0 for w in [alpha, beta, gamma]):
+            raise ValueError("Weights must be non-negative")
         total = alpha + beta + gamma
         if total == 0:
             total = 1


### PR DESCRIPTION
Closes #418.

Summary of What Has Been Done:
Modified the set_weights method in HybridRecommender to validate that weights are non-negative and not NaN before normalizing and setting them.

Changes Made:
Added validation in src/model/hybrid_model.py set_weights method:
- Check that alpha, beta, gamma are not NaN using math.isnan
- Check that all weights are >= 0
- Raise ValueError with descriptive message for invalid inputs

Impact it Made:
- Prevents model from using invalid weights
- Fail-fast behavior prevents subtle bugs
- Clear error messages for debugging