### PR TITLE
fix : handle None responses in LLMExplainer

### DIFF
--- a/src/model/llm_explainer.py
+++ b/src/model/llm_explainer.py
@@ -143,13 +143,17 @@ Generate a COMPLETE, FULL explanation (not truncated):"""
             )
 
             response = self.client.generate_content(prompt)
-            if response and response.text:
-                return response.text.strip()
-            else:
+            if response is None:
+                logger.warning("LLM returned None response, using fallback")
+                return self._generate_fallback_explanation(
+                    recommended_item, query_item, scores, description, category
+                )
+            if not hasattr(response, 'text') or response.text is None:
                 logger.warning("LLM returned empty response, using fallback")
                 return self._generate_fallback_explanation(
                     recommended_item, query_item, scores, description, category
                 )
+            return response.text.strip()
 
         except Exception as e:
             logger.error(f"Error generating LLM explanation: {e}. Using fallback explanation.")


### PR DESCRIPTION
Closes #420.

Summary of What Has Been Done:
Modified the explain_recommendation method to explicitly handle None responses from LLM client.generate_content.

Changes Made:
In src/model/llm_explainer.py, added explicit None check for response object before accessing response.text:
- Check if response is None explicitly
- Check if response.text is None or missing using hasattr
- Each case returns fallback explanation with appropriate warning

Impact it Made:
- Explicit handling of None response object
- Clearer error handling and logging
- Prevents AttributeError if response is None