### PR TITLE
feat: validate data adapter inputs

### DIFF
--- a/src/data/data_adapter.py
+++ b/src/data/data_adapter.py
@@ -158,6 +158,50 @@ def validate_dataframe(df):
     return True
 
 
+def _has_blank_values(series):
+    """Return True when a column contains nulls or blank string values."""
+    return series.isna().any() or series.astype(str).str.strip().eq('').any()
+
+
+def validate_recommender_inputs(df, user_col=None, item_id_col=None, title_col=None, rating_col=None):
+    """
+    Validate columns that feed the recommender pipeline before normalization.
+    """
+    missing = []
+    if user_col is None:
+        missing.append('user_id')
+    if item_id_col is None and title_col is None:
+        missing.append('item_id or title')
+    if rating_col is None:
+        missing.append('rating')
+
+    if missing:
+        raise ValueError(
+            "Interaction data is missing required column(s): "
+            + ", ".join(missing)
+        )
+
+    corrupted = []
+    for label, col in (('user_id', user_col), ('item_id', item_id_col), ('title', title_col)):
+        if col is not None and _has_blank_values(df[col]):
+            corrupted.append(label)
+
+    if _has_blank_values(df[rating_col]):
+        corrupted.append('rating')
+
+    ratings = pd.to_numeric(df[rating_col], errors='coerce')
+    if ratings.isna().any():
+        corrupted.append('rating must be numeric')
+
+    if corrupted:
+        raise ValueError(
+            "Interaction data contains invalid value(s) in: "
+            + ", ".join(dict.fromkeys(corrupted))
+        )
+
+    return True
+
+
 def read_file(path_or_buffer, file_format=None):
     """
     Read CSV or JSON into DataFrame.
@@ -227,6 +271,33 @@ def adapt_data(df):
 
     validate_dataframe(df)
 
+    raw_columns = df.columns
+    raw_title_col = detect_column(
+        raw_columns,
+        ['title', 'name', 'product_name', 'item_name']
+    )
+    raw_user_col = detect_column(
+        raw_columns,
+        ['user_id', 'user', 'reviewer', 'customer']
+    )
+    raw_rating_col = detect_column(
+        raw_columns,
+        ['rating', 'score', 'stars']
+    )
+    raw_item_id_col = detect_column(
+        raw_columns,
+        ['item_id', 'product_id', 'asin',
+         'isbn', 'book_id', 'movie_id']
+    )
+    if raw_user_col is not None or raw_rating_col is not None or raw_item_id_col is not None:
+        validate_recommender_inputs(
+            df,
+            user_col=raw_user_col,
+            item_id_col=raw_item_id_col,
+            title_col=raw_title_col,
+            rating_col=raw_rating_col,
+        )
+
     # Apply preprocessing automatically
 
     if 'authors' in df.columns or 'publisher' in df.columns:
@@ -288,6 +359,18 @@ def adapt_data(df):
         columns,
         ['purchases', 'orders', 'bought', 'transactions']
     )
+
+    is_interaction_data = (
+        user_col is not None or rating_col is not None or item_id_col is not None
+    )
+    if is_interaction_data:
+        validate_recommender_inputs(
+            df,
+            user_col=user_col,
+            item_id_col=item_id_col,
+            title_col=title_col,
+            rating_col=rating_col,
+        )
 
     df = df.copy()
 

--- a/tests/test_data_adapter_validation.py
+++ b/tests/test_data_adapter_validation.py
@@ -1,0 +1,50 @@
+import pytest
+import pandas as pd
+
+from src.data.data_adapter import adapt_data
+
+
+def test_adapt_data_accepts_valid_interaction_dataset():
+    df = pd.DataFrame({
+        "user_id": ["u1", "u2"],
+        "item_id": ["i1", "i2"],
+        "rating": [4.0, 5.0],
+        "title": ["Item One", "Item Two"],
+    })
+
+    adapted, meta = adapt_data(df)
+
+    assert meta["has_user_data"] is True
+    assert list(adapted["user_id"]) == ["u1", "u2"]
+
+
+def test_adapt_data_rejects_missing_interaction_columns():
+    df = pd.DataFrame({
+        "user_id": ["u1", "u2"],
+        "rating": [4.0, 5.0],
+    })
+
+    with pytest.raises(ValueError, match="item_id or title"):
+        adapt_data(df)
+
+
+def test_adapt_data_rejects_blank_core_identifiers():
+    df = pd.DataFrame({
+        "user_id": ["u1", " "],
+        "item_id": ["i1", "i2"],
+        "rating": [4.0, 5.0],
+    })
+
+    with pytest.raises(ValueError, match="user_id"):
+        adapt_data(df)
+
+
+def test_adapt_data_rejects_non_numeric_ratings():
+    df = pd.DataFrame({
+        "user_id": ["u1", "u2"],
+        "item_id": ["i1", "i2"],
+        "rating": [4.0, "bad"],
+    })
+
+    with pytest.raises(ValueError, match="rating must be numeric"):
+        adapt_data(df)


### PR DESCRIPTION
Closes #409.\n\n## What changed\n- Added explicit interaction dataset validation in the data adapter layer.\n- Rejects missing user/item/rating columns before preprocessing.\n- Rejects blank identifiers and non-numeric ratings with descriptive ValueError messages.\n- Added focused data adapter validation tests.\n\n## Why\nMalformed interaction data previously failed deeper in preprocessing or model code with cryptic pandas/sklearn errors. Validating at the adapter boundary gives contributors and API callers clear feedback about what is missing or corrupted.\n\n## How to test\n- python -m pytest tests/test_data_adapter_validation.py\n- git diff --check