### PR TITLE
feat: add popularity fallback recommendations

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -222,6 +222,9 @@ class HybridRecommender:
             results.append(result)
 
         results.sort(key=lambda x: x['hybrid_score'], reverse=True)
+        if not results:
+            return self.get_popular_fallback_items(top_n=top_n, exclude_title=title)
+
         return results[:top_n]
 
     def _build_explanation(
@@ -286,7 +289,7 @@ class HybridRecommender:
     def _cold_start_fallback(self, title, top_n):
         """
         Fallback when no model data exists for the title.
-        Returns popular items from the same category.
+        Returns popular items from the same category or global popularity.
         """
         if self.item_df is None:
             return []
@@ -299,15 +302,40 @@ class HybridRecommender:
             if len(cat_items) >= top_n:
                 df = cat_items
 
+        return self.get_popular_fallback_items(
+            top_n=top_n,
+            source_df=df,
+            exclude_title=title,
+        )
+
+    def get_popular_fallback_items(self, top_n=5, source_df=None, exclude_title=None):
+        """
+        Return globally popular items when personalization produces no candidates.
+        """
+        if self.item_df is None and source_df is None:
+            return []
+
+        df = source_df if source_df is not None else self.item_df
+        if df is None or len(df) == 0:
+            return []
+
+        df = df.copy()
+        if exclude_title is not None and 'title' in df.columns:
+            df = df[df['title'] != exclude_title]
+
         # Sort by Bayesian rating
         if 'rating' in df.columns and 'review_count' in df.columns:
-            df = df.copy()
             df['_bayesian'] = df.apply(
                 lambda r: bayesian_rating(r['rating'], r.get('review_count', 0)), axis=1
             )
-            df = df.sort_values('_bayesian', ascending=False)
+            df = df.sort_values(
+                ['_bayesian', 'review_count'],
+                ascending=[False, False],
+            )
         elif 'rating' in df.columns:
             df = df.sort_values('rating', ascending=False)
+        elif 'review_count' in df.columns:
+            df = df.sort_values('review_count', ascending=False)
 
         results = []
         for _, row in df.head(top_n).iterrows():

--- a/tests/test_hybrid_popularity_fallback.py
+++ b/tests/test_hybrid_popularity_fallback.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+from src.model.hybrid_model import HybridRecommender
+
+
+class EmptyContentModel:
+    def __init__(self, df):
+        self.df = df
+
+    def recommend(self, title, top_n=10):
+        return []
+
+
+def make_recommender():
+    item_df = pd.DataFrame({
+        "title": ["Product A", "Product B", "Product C"],
+        "description": ["A", "B", "C"],
+        "category": ["Electronics", "Electronics", "Home"],
+        "rating": [4.5, 3.8, 4.9],
+        "review_count": [120, 45, 200],
+        "avg_sentiment": [0.6, 0.2, 0.8],
+    })
+    return HybridRecommender(EmptyContentModel(item_df), item_df=item_df)
+
+
+def test_unknown_item_uses_global_popularity_fallback():
+    recs = make_recommender().recommend("Unknown Product", top_n=2)
+
+    assert [rec["title"] for rec in recs] == ["Product C", "Product A"]
+
+
+def test_popularity_fallback_excludes_source_title():
+    recs = make_recommender().get_popular_fallback_items(
+        top_n=3,
+        exclude_title="Product C",
+    )
+
+    titles = [rec["title"] for rec in recs]
+    assert "Product C" not in titles
+    assert titles[0] == "Product A"


### PR DESCRIPTION
Closes #410.\n\n## What changed\n- Added a reusable popular fallback recommendation utility.\n- Returns global/category popular items when personalization yields no candidates.\n- Excludes the source title from fallback payloads.\n- Added focused tests with a lightweight fake content model.\n\n## Why\nAbsolute cold starts can leave the recommendation payload empty, which creates a weak first-run experience and can break frontend assumptions. A popularity fallback keeps responses useful without changing the main hybrid scoring weights.\n\n## How to test\n- python -m pytest tests/test_hybrid_popularity_fallback.py\n- git diff --check