### PR TITLE
[codex] Initialize product review counts during Supabase import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -573,6 +573,8 @@ async def upload_dataset(file: UploadFile = File(...)):
                     'description': str(row.get('description', ''))[:2000],
                     'category': str(row.get('category', ''))[:200],
                     'rating': round(rating_val, 2),
+                    'avg_sentiment': 0.0,
+                    'review_count': 0,
                     'metadata': {},
                 })
             if not rows:

--- a/scripts/import_to_supabase.py
+++ b/scripts/import_to_supabase.py
@@ -15,13 +15,41 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import pandas as pd
 from tqdm import tqdm
 from src.data.data_adapter import adapt_data
-from src.model.nlp_engine import analyze_sentiment
 from src.data.db import get_supabase_admin
 
 
 def chunked(df, size):
     for start in range(0, len(df), size):
         yield df.iloc[start:start + size]
+
+
+def _safe_float(value, default=0.0):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return number if pd.notna(number) else default
+
+
+def _safe_int(value, default=0):
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(number, default)
+
+
+def build_product_row(row):
+    """Normalize one adapted product row for the Supabase products table."""
+    return {
+        'title': str(row.get('title', 'Unknown'))[:500],
+        'description': str(row.get('description', ''))[:2000],
+        'category': str(row.get('category', ''))[:200],
+        'rating': _safe_float(row.get('rating', 0)),
+        'avg_sentiment': _safe_float(row.get('sentiment', 0)),
+        'review_count': _safe_int(row.get('review_count', 0)),
+        'metadata': {},
+    }
 
 
 def import_dataset(file_path, batch_size=1000, run_sentiment=False):
@@ -54,6 +82,8 @@ def import_dataset(file_path, batch_size=1000, run_sentiment=False):
 
     # Sentiment analysis (optional — slow on large datasets)
     if run_sentiment and 'review_text' in adapted_df.columns:
+        from src.model.nlp_engine import analyze_sentiment
+
         print("  Running sentiment analysis...")
         adapted_df['sentiment'] = adapted_df['review_text'].apply(
             lambda x: analyze_sentiment(str(x)) if pd.notna(x) and str(x).strip() else 0.0
@@ -69,14 +99,7 @@ def import_dataset(file_path, batch_size=1000, run_sentiment=False):
     for chunk in tqdm(list(chunked(adapted_df, batch_size)), desc="  Uploading"):
         rows = []
         for _, row in chunk.iterrows():
-            rows.append({
-                'title': str(row.get('title', 'Unknown'))[:500],
-                'description': str(row.get('description', ''))[:2000],
-                'category': str(row.get('category', ''))[:200],
-                'rating': float(row.get('rating', 0)) if pd.notna(row.get('rating')) else 0.0,
-                'avg_sentiment': float(row.get('sentiment', 0)) if pd.notna(row.get('sentiment')) else 0.0,
-                'metadata': {},
-            })
+            rows.append(build_product_row(row))
 
         try:
             result = sb.table('products').upsert(

--- a/supabase/migrations/002_create_products_table.sql
+++ b/supabase/migrations/002_create_products_table.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- Migration: Create/repair products table used by import, search, and model build
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS products (
+    id            BIGSERIAL   PRIMARY KEY,
+    title         TEXT        NOT NULL,
+    description   TEXT        NOT NULL DEFAULT '',
+    category      TEXT        NOT NULL DEFAULT '',
+    rating        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    avg_sentiment DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    review_count  INTEGER     NOT NULL DEFAULT 0,
+    metadata      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT 'Untitled',
+    ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS rating DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    ADD COLUMN IF NOT EXISTS avg_sentiment DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    ADD COLUMN IF NOT EXISTS review_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE products
+    ALTER COLUMN title DROP DEFAULT;
+
+UPDATE products
+SET review_count = 0
+WHERE review_count IS NULL;
+
+ALTER TABLE products
+    ALTER COLUMN review_count SET DEFAULT 0,
+    ALTER COLUMN review_count SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'products_review_count_nonnegative'
+          AND conrelid = 'products'::regclass
+    ) THEN
+        ALTER TABLE products
+            ADD CONSTRAINT products_review_count_nonnegative
+            CHECK (review_count >= 0);
+    END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_products_title_unique
+    ON products (title);
+
+CREATE INDEX IF NOT EXISTS idx_products_rating_review_count
+    ON products (rating DESC, review_count DESC);
+
+ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'products'
+          AND policyname = 'Anyone can read products'
+    ) THEN
+        CREATE POLICY "Anyone can read products"
+            ON products FOR SELECT
+            USING (true);
+    END IF;
+END
+$$;

--- a/tests/test_import_to_supabase.py
+++ b/tests/test_import_to_supabase.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from scripts import import_to_supabase
+
+
+class FakeProductsTable:
+    def __init__(self):
+        self.rows = []
+        self.calls = []
+
+    def upsert(self, rows, **kwargs):
+        self.rows.extend(rows)
+        self.calls.append(("upsert", rows, kwargs))
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.rows)
+
+
+class FakeSupabase:
+    def __init__(self):
+        self.products = FakeProductsTable()
+
+    def table(self, name):
+        assert name == "products"
+        return self.products
+
+
+def test_build_product_row_initializes_review_count():
+    row = pd.Series({
+        "title": "Widget",
+        "description": "Useful widget",
+        "category": "Tools",
+        "rating": "4.5",
+        "sentiment": "0.25",
+    })
+
+    product = import_to_supabase.build_product_row(row)
+
+    assert product == {
+        "title": "Widget",
+        "description": "Useful widget",
+        "category": "Tools",
+        "rating": 4.5,
+        "avg_sentiment": 0.25,
+        "review_count": 0,
+        "metadata": {},
+    }
+
+
+def test_import_dataset_sends_review_count_to_supabase(tmp_path, monkeypatch):
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text(
+        "title,description,category,rating\n"
+        "Widget,Useful widget,Tools,4.5\n"
+        "Book,Readable book,Books,3.5\n",
+        encoding="utf-8",
+    )
+    fake_supabase = FakeSupabase()
+    monkeypatch.setattr(import_to_supabase, "get_supabase_admin", lambda: fake_supabase)
+
+    imported = import_to_supabase.import_dataset(str(csv_path), batch_size=2)
+
+    assert imported == 2
+    assert len(fake_supabase.products.rows) == 2
+    assert all(row["review_count"] == 0 for row in fake_supabase.products.rows)
+    assert all("review_count" in row for row in fake_supabase.products.rows)


### PR DESCRIPTION
## What changed\n- Added a Supabase products migration that creates or repairs the review_count column with INTEGER NOT NULL DEFAULT 0.\n- Included review_count in the batch importer and API upload payloads so imported rows match the backend /api/build select shape.\n- Added importer tests covering the normalized product row and Supabase upsert payload.\n\n## Why\n/api/build selects review_count, but fresh/imported Supabase product rows were initialized without that schema field. On a fresh database this can surface as a PostgREST 42703 missing-column error.\n\n## How to test\n- python3 -m pytest tests/test_import_to_supabase.py\n- env PYTHONPYCACHEPREFIX=/private/tmp/pycache-hybrid-439 python3 -m py_compile scripts/import_to_supabase.py backend/main.py\n- git diff --check\n\nBroader backend tests were attempted with python3 -m pytest tests/test_import_to_supabase.py tests/test_upload_validation.py tests/test_search_api.py, but collection failed because this local Python environment does not have nltk installed and backend/main.py imports src.model.nlp_engine at module load.\n\nFixes #439