### PR TITLE
fix : enforced ge=1, le=365 validation on days in get_trending_products

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -904,7 +904,10 @@ TRENDING_CACHE = {
 
 
 @app.get("/api/trending")
-def get_trending_products(days: int = 7, limit: int = 10):
+def get_trending_products(
+    days: int = Query(7, ge=1, le=365),
+    limit: int = Query(10, ge=1, le=100),
+):
     """
     Get trending products based on recent interactions.
     """

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+from backend import main
+
+client = TestClient(main.app)
+
+
+def test_trending_validation_bounds():
+    # Test valid defaults
+    # Since we don't have Supabase credentials in tests, it will try to call get_supabase()
+    # and fail with RuntimeError unless it's mocked or caught by cache/empty.
+    # Let's mock get_supabase to see if validation fails first.
+    # FastAPI path/query validation happens BEFORE the route function starts, 
+    # so invalid parameters will fail with 422 immediately without calling the function or get_supabase!
+    
+    # Test negative days
+    response = client.get("/api/trending?days=-1")
+    assert response.status_code == 422
+
+    # Test excessive days
+    response = client.get("/api/trending?days=366")
+    assert response.status_code == 422
+
+    # Test limit negative
+    response = client.get("/api/trending?limit=0")
+    assert response.status_code == 422
+
+    # Test limit excessive
+    response = client.get("/api/trending?limit=101")
+    assert response.status_code == 422


### PR DESCRIPTION
Closes #465.

Summary of What Has Been Done:
Enforced Query input validations on the days parameter (ge=1, le=365) and limit parameter (ge=1, le=100) inside the get_trending_products endpoint.

Changes Made:
- backend/main.py: Updated parameters of get_trending_products to include Query constraints.
- tests/test_trending.py: Created test file verifying Query validation bounds for /api/trending.

Impact it Made:
Protects trending products endpoint from negative/invalid limits and excessively large days requests.