### PR TITLE
fix : validated user_id and product_id bounds in create_purchase

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, Optional
 from dotenv import load_dotenv
 
@@ -272,9 +272,9 @@ class WeightsUpdate(BaseModel):
 class PurchaseCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    user_id: str
-    product_id: int
-    rating: float = 0.0
+    user_id: str = Field(..., min_length=1)
+    product_id: int = Field(..., gt=0)
+    rating: float = Field(0.0, ge=0.0, le=5.0)
     review_text: str = ""
 
 

--- a/tests/test_purchases.py
+++ b/tests/test_purchases.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+from types import SimpleNamespace
+from backend import main
+
+client = TestClient(main.app)
+
+
+class FakeQuery:
+    def __init__(self, data):
+        self.data = data
+
+    def insert(self, *args, **kwargs):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.data)
+
+
+class FakeSupabase:
+    def __init__(self, table_query):
+        self.table_query = table_query
+
+    def table(self, name):
+        assert name == "purchases"
+        return self.table_query
+
+
+def test_create_purchase_validation_failures():
+    # Empty user_id should fail
+    response = client.post("/api/purchases", json={"user_id": "", "product_id": 123})
+    assert response.status_code == 422
+
+    # Negative product_id should fail
+    response = client.post("/api/purchases", json={"user_id": "user123", "product_id": -5})
+    assert response.status_code == 422
+
+    # Out of bounds rating should fail
+    response = client.post("/api/purchases", json={"user_id": "user123", "product_id": 123, "rating": 6.0})
+    assert response.status_code == 422
+
+
+def test_create_purchase_success(monkeypatch):
+    mock_response = [{"id": 1, "user_id": "user123", "product_id": 123, "rating": 4.5, "review_text": "Good!"}]
+    query_mock = FakeQuery(mock_response)
+    monkeypatch.setattr(main, "get_supabase", lambda: FakeSupabase(query_mock))
+
+    response = client.post(
+        "/api/purchases",
+        json={"user_id": "user123", "product_id": 123, "rating": 4.5, "review_text": "Good!"}
+    )
+    assert response.status_code == 200
+    
+    payload = response.json()
+    assert "purchase" in payload
+    assert payload["purchase"][0]["user_id"] == "user123"


### PR DESCRIPTION
Closes #469.

Summary of What Has Been Done:
Added input validation constraints to the create purchase API by wrapping the PurchaseCreate Pydantic model with Field validators, enforcing user_id (min_length=1), product_id (gt=0), and rating (ge=0.0, le=5.0).

Changes Made:
- backend/main.py: Imported Field and updated PurchaseCreate fields with range constraints.
- tests/test_purchases.py: Created test suite verifying input validation failure cases and successful purchase insertions.

Impact it Made:
Secures and validates transaction inputs at the API boundary before hitting database tables.