### PR TITLE
fix: strengthen redirect URL validation

### DIFF
--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -12,10 +12,16 @@ export function getStars(rating) {
  * @returns {boolean}
  */
 export function isSafeRedirect(url) {
-    if (!url) return false;
-    // Allow relative URLs (starts with '/')
-    if (url.startsWith('/')) return true;
-    // Allow same‑origin absolute URLs
+    if (!url || typeof url !== 'string') {
+        return false;
+    }
+
+    // Allow only safe internal relative paths
+    if (url.startsWith('/') && !url.startsWith('//')) {
+        return true;
+    }
+
+    // Allow same-origin absolute URLs only
     try {
         const target = new URL(url, window.location.origin);
         return target.origin === window.location.origin;


### PR DESCRIPTION
## Related Issue

Fixes #301

## What Changed

* Improved `isSafeRedirect()` validation logic
* Blocked protocol-relative URLs like `//evil.com`
* Allowed only safe internal relative paths
* Preserved same-origin absolute URL validation

## Security Impact

This mitigates potential open redirect phishing attacks by preventing unsafe external redirects.

## Testing

Tested redirect validation manually in browser console:

* `isSafeRedirect('/dashboard')` → `true`
* `isSafeRedirect('https://evil.com')` → `false`
* `isSafeRedirect('//evil.com')` → `false`
