### PR TITLE
docs: add standard GitHub Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description
+Please include a summary of the change and which issue is fixed.
+
+Fixes #516
+
+## Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [x] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Checklist:
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my own code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] My changes generate no new warnings


### PR DESCRIPTION
This PR adds a structured pull request template in `.github/pull_request_template.md` to help maintain high quality contributions.

Fixes #516