### PR TITLE
chore: add .editorconfig file for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This PR adds an `.editorconfig` file in the project root to enforce indentation size, formatting, line ending, and newline standards across editors.

Fixes #517