### PR TITLE
chore: add .prettierrc for frontend and ruff config in pyproject.toml

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+# Target Python version
+target-version = "py310"
+
+# Exclude commonly ignored directories
+exclude = [
+    ".git",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+]
+
+# Set maximum line length to 100 characters (consistent with existing codebase)
+line-length = 100
+
+[tool.ruff.format]
+# Enforce double quotes for formatting (standard Python practice)
+quote-style = "double"
+
+# Use spaces instead of tabs
+indent-style = "space"
+
+# Enforce PEP 8 line wrap style
+line-ending = "auto"


### PR DESCRIPTION
## What changed
- Added `frontend/.prettierrc` scoped to the frontend directory with standard formatting rules (2-space indent, single quotes, 100-char print width, semicolons enabled)
- Added `pyproject.toml` at the project root with `[tool.ruff]` and `[tool.ruff.format]` configuration enforcing 100-char line length, PEP 8 spacing, and double quotes for Python files

## Why
Closes #519 — without explicit formatter configs, different developers' editors apply inconsistent formatting rules, causing noisy diffs and style inconsistencies. This establishes a single source of truth for both frontend (Prettier) and backend (Ruff) formatting.

## How to test
```bash
# Verify Prettier reads the frontend config
npx prettier --check "frontend/**/*.js"

# Verify Ruff reads the pyproject.toml config
ruff format --check .
```

## Screenshots (if UI change)
N/A — config files only, no UI changes.

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #519

## AI assistance disclosure
- [x] I used AI assistance for: drafting the ruff and prettier configuration structure. All settings reviewed, understood, and verified locally before submission.