### PR TITLE
Chore/add eslint ruff lint config

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "no-console": "off",
+    "eqeqeq": ["error", "always"],
+    "curly": ["error", "all"],
+    "semi": ["error", "always"],
+    "quotes": ["error", "single", { "avoidEscape": true }]
+  }
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+# Target Python version
+target-version = "py310"
+
+# Exclude commonly ignored directories
+exclude = [
+    ".git",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+]
+
+# Set maximum line length to 100 characters (consistent with existing codebase)
+line-length = 100
+
+[tool.ruff.format]
+# Enforce double quotes for formatting (standard Python practice)
+quote-style = "double"
+
+# Use spaces instead of tabs
+indent-style = "space"
+
+# Enforce PEP 8 line wrap style
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,22 @@ exclude = [
 # Set maximum line length to 100 characters (consistent with existing codebase)
 line-length = 100
 
+[tool.ruff.lint]
+# Enable standard lint rules:
+# E/W: pycodestyle errors/warnings
+# F: Pyflakes (unused imports, variables, etc.)
+# I: isort (import sorting)
+# B: flake8-bugbear (common bug patterns)
+# C4: flake8-comprehensions (optimized list/dict comprehensions)
+# UP: pyupgrade (enforces modern Python features)
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+
+ignore = []
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["backend", "src"]
+
 [tool.ruff.format]
 # Enforce double quotes for formatting (standard Python practice)
 quote-style = "double"


### PR DESCRIPTION
## What changed
- Appended `[tool.ruff.lint]` and `[tool.ruff.lint.isort]` sections to the existing `pyproject.toml`, enabling PEP 8 compliance, unused import/variable detection, import sorting, and modern Python upgrade rules
- Added `frontend/.eslintrc.json` scoped to the frontend directory (`"root": true`) with `eslint:recommended` base, strict equality, curly braces, semicolons, and single-quote enforcement for browser ES modules

## Why
Closes #520 — without explicit linting configuration, static analysis tools either run unconfigured or not at all, allowing unused imports, unsorted imports, and minor bugs to go undetected across both the Python backend and JavaScript frontend.

## How to test
```bash
# Verify Ruff reads the lint config and flags violations
ruff check .

# Verify ESLint reads the frontend config
npx eslint "frontend/**/*.js"
```

## Screenshots (if UI change)
N/A — config files only, no UI changes.

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #520

## AI assistance disclosure
- [x] I used AI assistance for: drafting the ruff lint rule selection and ESLint config structure. All settings reviewed, understood, and verified locally before submission.