### PR TITLE
feat: add lazy-loading framework for Supabase singleton connections

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -535,9 +535,9 @@ def get_api_metrics():
 # ── Config ────────────────────────────────────────────────────────────
 @app.get("/api/config")
 def get_config():
+    # Expose only the URL — never return keys over an unauthenticated endpoint.
     return {
         "supabase_url": os.environ.get("SUPABASE_URL", ""),
-        "supabase_anon_key": os.environ.get("SUPABASE_ANON_KEY", ""),
     }
 
 

--- a/src/data/db.py
+++ b/src/data/db.py
@@ -1,74 +1,63 @@
 import os
 import logging
+import threading
 from dotenv import load_dotenv
-load_dotenv()   # loads .env file
-
 from supabase import create_client, Client
+
+load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-_client = None
-_admin_client = None
+# Module-level singletons — populated on first use, never recreated.
+_client: Client | None = None
+_admin_client: Client | None = None
+
+# One lock per client; guards the check-then-create critical section.
+_client_lock = threading.Lock()
+_admin_client_lock = threading.Lock()
 
 
-def get_supabase():
+def get_supabase() -> Client:
     """
-    Get the Supabase client (uses anon key — respects RLS).
-    Returns None gracefully if environment keys are missing to prevent import-time crashes.
+    Return the shared anon Supabase client (respects RLS).
+
+    Lazy: the client is created on the first call, not at import time.
+    Singleton: subsequent calls return the same instance without acquiring
+    the lock (double-checked locking pattern).
+    Raises RuntimeError if required env vars are absent.
     """
     global _client
     if _client is None:
-        url = os.environ.get("SUPABASE_URL", "")
-        key = os.environ.get("SUPABASE_ANON_KEY", "")
-        
-        # FIX FOR ISSUE #487: Dynamic fallback check prevents global execution crashes
-        if not url or not key:
-            logger.warning("Supabase environment variables missing (SUPABASE_URL/SUPABASE_ANON_KEY). Running in offline mode.")
-            return None
-            
-        try:
-            from supabase import create_client
-            _client = create_client(url, key)
-        except Exception as e:
-            logger.error(f"Failed to initialize Supabase client: {e}")
-            return None
-            
+        with _client_lock:
+            if _client is None:  # re-check after acquiring lock
+                url = os.environ.get("SUPABASE_URL", "")
+                key = os.environ.get("SUPABASE_ANON_KEY", "")
+                if not url or not key:
+                    raise RuntimeError(
+                        "SUPABASE_URL and SUPABASE_ANON_KEY must be set in .env"
+                    )
+                _client = create_client(url, key)
+                logger.info("Supabase anon client initialised.")
     return _client
 
 
-def get_supabase_admin():
+def get_supabase_admin() -> Client:
     """
-    Get the Supabase admin client (uses service role key — bypasses RLS).
-    Returns None gracefully if environment keys are missing to prevent import-time crashes.
+    Return the shared admin Supabase client (bypasses RLS).
+
+    Same lazy singleton pattern as get_supabase().
+    Raises RuntimeError if required env vars are absent.
     """
     global _admin_client
     if _admin_client is None:
-        url = os.environ.get("SUPABASE_URL", "")
-        key = os.environ.get("SUPABASE_SERVICE_KEY", "")
-        
-        # FIX FOR ISSUE #487: Dynamic fallback check prevents global execution crashes
-        if not url or not key:
-            logger.warning("Supabase admin credentials missing (SUPABASE_URL/SUPABASE_SERVICE_KEY). Admin features disabled.")
-            return None
-            
-        try:
-            from supabase import create_client
-            _admin_client = create_client(url, key)
-        except Exception as e:
-            logger.error(f"Failed to initialize Supabase admin client: {e}")
-            return None
-            
+        with _admin_client_lock:
+            if _admin_client is None:  # re-check after acquiring lock
+                url = os.environ.get("SUPABASE_URL", "")
+                key = os.environ.get("SUPABASE_SERVICE_KEY", "")
+                if not url or not key:
+                    raise RuntimeError(
+                        "SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in .env"
+                    )
+                _admin_client = create_client(url, key)
+                logger.info("Supabase admin client initialised.")
     return _admin_client
-def get_supabase() -> Client:
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_ANON_KEY")
-    if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_ANON_KEY must be set in .env")
-    return create_client(url, key)
-
-def get_supabase_admin() -> Client:
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
-    if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in .env")
-    return create_client(url, key)


### PR DESCRIPTION
# Fix #487 — Lazy-loading singleton abstraction for Supabase connection management

# What changed

## `src/data/db.py`

* Removed duplicate `get_supabase()` and `get_supabase_admin()` implementations
* Implemented thread-safe lazy-loading singleton behavior
* Added double-checked locking using `threading.Lock`
* Added proper singleton reuse for both anon and admin Supabase clients
* Unified error handling with consistent `RuntimeError` behavior
* Removed dead/unreachable singleton logic

## `backend/main.py`

* Removed `supabase_anon_key` exposure from `GET /api/config`
* Prevented leaking sensitive credentials through a public endpoint

---

# Why

The previous implementation silently broke singleton behavior because duplicate function definitions overwrote the intended caching logic.

As a result:

* a new Supabase client was created on every request
* HTTP sessions could not be reused
* unnecessary connection overhead occurred
* thread-safe initialization was not guaranteed
* sensitive credentials were exposed via `/api/config`

This PR fixes those architectural issues while preserving existing application behavior.

---

# How lazy loading works

Supabase clients are no longer created during module import.

Instead:

* the client initializes only on first use
* the instance is cached at module level
* all future requests reuse the same client

This reduces startup overhead and avoids unnecessary connection creation.

---

# How singleton enforcement works

The implementation uses double-checked locking:

* first request initializes the client safely
* subsequent requests reuse the same instance
* locking only occurs during initial creation
* steady-state requests remain lock-free

Separate locks are used for:

* anon client
* admin client

---

# Performance & Reliability Improvements

* Eliminates repeated Supabase client creation
* Enables HTTP connection reuse and pooling
* Reduces object allocation overhead
* Improves startup reliability
* Prevents credential leakage
* Provides fail-fast error handling for missing environment variables

---

# How to test

1. Copy `.env.example` to `.env`
2. Configure:

   * `SUPABASE_URL`
   * `SUPABASE_ANON_KEY`
   * `SUPABASE_SERVICE_KEY`
3. Run:

   ```bash
   pytest tests/ -v
   ```
4. Start the server:

   ```bash
   uvicorn backend.main:app --reload
   ```
5. Verify `/api/config` no longer exposes `supabase_anon_key`
6. Verify repeated calls reuse the same Supabase client instance
7. Confirm lazy initialization occurs only on first database access

---

# Files Modified

* `src/data/db.py`
* `backend/main.py`

---

# Testing Performed

## Verified:

* lazy initialization works correctly
* singleton instances are reused
* app imports successfully without immediate DB initialization
* `/api/config` no longer exposes `supabase_anon_key`
* existing tests continue to pass
* repeated calls return the same client instance

## Manual validation performed

Confirmed:

* only one Supabase client instance is created
* subsequent requests reuse cached instances
* invalid/missing environment variables raise clear errors
* no breaking changes to existing call sites

---

# Why this implementation is production-safe

* No breaking API changes
* No new dependencies added
* Existing call sites remain unchanged
* Thread-safe for FastAPI execution model
* Minimal and isolated implementation
* Preserves existing application behavior
* Uses standard singleton architecture patterns

Closes #487