### PR TITLE
fix : removed duplicate function definitions in db.py

### DIFF
--- a/src/data/db.py
+++ b/src/data/db.py
@@ -59,16 +59,3 @@ def get_supabase_admin():
             return None
             
     return _admin_client
-def get_supabase() -> Client:
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_ANON_KEY")
-    if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_ANON_KEY must be set in .env")
-    return create_client(url, key)
-
-def get_supabase_admin() -> Client:
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
-    if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in .env")
-    return create_client(url, key)


### PR DESCRIPTION
Refs #553.

Summary of What Has Been Done:
Removed duplicate function definitions for get_supabase and get_supabase_admin in src/data/db.py. The file previously had two definitions of each function: the first with graceful error handling (returning None when credentials are missing) and the second that raised RuntimeError immediately. Kept only the first set of implementations which handle missing credentials gracefully.

Changes Made:
Modified src/data/db.py:
- Removed duplicate get_supabase() function (second definition)
- Removed duplicate get_supabase_admin() function (second definition)
- Kept only the implementations that return None gracefully when environment variables are missing

Impact it Made:
Prevents potential bugs from duplicate function definitions. The remaining implementations provide offline mode support when Supabase credentials are not configured, improving the robustness of the application.