### PR TITLE
fix : added empty keywords check in detect_column

### DIFF
--- a/src/data/data_adapter.py
+++ b/src/data/data_adapter.py
@@ -127,6 +127,9 @@ def preprocess_sentiment_data(df):
 
 def detect_column(columns, keywords):
     """Detect a column by matching against a list of keywords (case-insensitive)."""
+    if not keywords:
+        return None
+
     # First pass: exact matches
     for key in keywords:
         for col in columns:


### PR DESCRIPTION
Refs #557.

Summary of What Has Been Done:
Fixed the detect_column function in src/data/data_adapter.py to handle the edge case where the keywords list is empty. The function now returns None immediately when keywords is empty, preventing potential issues.

Changes Made:
Modified src/data/data_adapter.py:
- Added early return check at the start of detect_column function
- Returns None immediately if keywords is empty or falsy

Impact it Made:
Prevents potential crashes or unexpected behavior when detect_column is called with an empty keywords list.