### PR TITLE
chore: add .gitattributes to manage line endings (#518)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Specific file types
+*.js text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
+*.bat text eol=crlf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.txt text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar.gz binary


### PR DESCRIPTION
## What changed
Added a `.gitattributes` file in the project root with rules to normalize line endings across platforms:
- `* text=auto` auto-detects text files
- Explicit rules for `.js`, `.html`, `.css`, `.json`, `.md`, `.py`, `.sh`, `.bat`, `.yml`, `.yaml`, `.txt` files (all use `eol=lf` except `.bat` which uses `crlf`)
- Binary files (images, PDFs, archives) marked as `binary` to prevent corruption

## Why
Prevents inconsistent line endings (LF vs CRLF) between Windows and Unix/Linux contributors. This eliminates spurious diffs and makes collaboration smoother.

## How to test
1. Check out this branch on a Windows machine:
   ```bash
   git checkout fix/gitattributes-518
   git config core.autocrlf false

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #518 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: formatting
