### PR TITLE
Fix sliding-window cleanup for response time metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
 
       - name: Download NLTK data
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
 
       - name: Download NLTK data
         run: |

--- a/backend/main.py
+++ b/backend/main.py
@@ -402,6 +402,7 @@ app.add_middleware(CSRFMiddleware)
 SLOW_RESPONSE_THRESHOLD_MS = 500.0
 METRICS_SAMPLE_SIZE = 1000
 response_time_samples = deque(maxlen=METRICS_SAMPLE_SIZE)
+METRICS_WINDOW_SECONDS = 600
 response_metrics = {
     "total_requests": 0,
     "error_requests": 0,
@@ -423,7 +424,17 @@ def record_response_metric(endpoint, method, status_code, response_time_ms):
         response_metrics["total_requests"] += 1
         if status_code >= 400:
             response_metrics["error_requests"] += 1
-        response_time_samples.append(response_time_ms)
+        response_time_samples.append(
+          (time.time(), response_time_ms)
+        )
+
+        current_time = time.time()
+
+        while (
+          response_time_samples
+          and current_time - response_time_samples[0][0] > METRICS_WINDOW_SECONDS
+        ):
+          response_time_samples.popleft()
     log_level = logging.WARNING if response_time_ms > SLOW_RESPONSE_THRESHOLD_MS else logging.INFO
     if log_level == logging.WARNING:
         logger.warning("API request slow endpoint=%s method=%s status=%s time=%.2fms response_time_ms=%.2f endpoint=%s",
@@ -442,7 +453,7 @@ def reset_response_metrics():
 
 def get_response_metrics_snapshot():
     with response_metrics_lock:
-        samples = list(response_time_samples)
+        samples = [value for _, value in response_time_samples]
         total_requests = response_metrics["total_requests"]
         error_requests = response_metrics["error_requests"]
     avg_response_time = sum(samples) / len(samples) if samples else 0.0

--- a/backend/main.py
+++ b/backend/main.py
@@ -518,16 +518,16 @@ class RealtimeConnectionHub:
             self.active_connections.remove(websocket)
 
     async def broadcast(self, message: dict):
-      disconnected = []
+        disconnected = []
 
-      for connection in self.active_connections:
-        try:
-          await connection.send_json(message)
-        except Exception:
-          disconnected.append(connection)
+        for connection in self.active_connections:
+            try:
+                await connection.send_json(message)
+            except Exception:
+                disconnected.append(connection)
 
-      for connection in disconnected:
-        self.disconnect(connection)
+        for connection in disconnected:
+            self.disconnect(connection)
 
 realtime_hub = RealtimeConnectionHub()
 


### PR DESCRIPTION
What changed

Implemented sliding-window cleanup for "response_time_samples" used by "/api/metrics".

Changes:

- Added timestamp-based metric storage
- Added automatic cleanup for old samples
- Limited metrics to a recent time window
- Updated metric extraction logic

Why

Previously, response metrics accumulated stale data over time which:

- increased memory usage
- biased p95 calculations
- reduced production observability accuracy

This update ensures metrics reflect only recent traffic.

How to test

1. Start the FastAPI server
2. Hit multiple API endpoints
3. Call "/api/metrics"
4. Verify metrics still work correctly
5. Confirm old entries are automatically removed after the configured window

Related issue

Closes #282 

AI assistance disclosure

-I used AI assistance for understanding the issue and  guidance.