### PR TITLE
feat: implement feature store for centralized user and item embedding…

### DIFF
--- a/src/model/feature_store.py
+++ b/src/model/feature_store.py
@@ -1,0 +1,44 @@
+
+import numpy as np
+import pickle
+import os
+
+class FeatureStore:
+    """
+    Centralized store for user and item embeddings.
+    Used by HybridRecommender to cache and retrieve embeddings
+    instead of recomputing them on every request.
+    """
+
+    def __init__(self, store_path="src/model/data"):
+        self.store_path = store_path
+        os.makedirs(store_path, exist_ok=True)
+        self._user_embeddings = {}
+        self._item_embeddings = {}
+
+    def save_user_embedding(self, user_id, embedding):
+        self._user_embeddings[user_id] = embedding
+        self._persist("user_embeddings.pkl", self._user_embeddings)
+
+    def get_user_embedding(self, user_id):
+        self._load("user_embeddings.pkl", self._user_embeddings)
+        return self._user_embeddings.get(user_id, None)
+
+    def save_item_embedding(self, item_id, embedding):
+        self._item_embeddings[item_id] = embedding
+        self._persist("item_embeddings.pkl", self._item_embeddings)
+
+    def get_item_embedding(self, item_id):
+        self._load("item_embeddings.pkl", self._item_embeddings)
+        return self._item_embeddings.get(item_id, None)
+
+    def _persist(self, filename, data):
+        path = os.path.join(self.store_path, filename)
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    def _load(self, filename, target):
+        path = os.path.join(self.store_path, filename)
+        if os.path.exists(path) and not target:
+            with open(path, "rb") as f:
+                target.update(pickle.load(f))

--- a/tests/test_feature_store.py
+++ b/tests/test_feature_store.py
@@ -1,0 +1,29 @@
+import sys
+sys.path.insert(0, '.')
+
+import numpy as np
+import pickle
+import os
+
+# Import directly, bypassing __init__.py
+from src.model.feature_store import FeatureStore
+
+def test_save_and_get_user_embedding(tmp_path):
+    store = FeatureStore(store_path=str(tmp_path))
+    vec = np.array([0.1, 0.2, 0.3])
+    store.save_user_embedding("user_1", vec)
+    assert np.allclose(store.get_user_embedding("user_1"), vec)
+
+def test_save_and_get_item_embedding(tmp_path):
+    store = FeatureStore(store_path=str(tmp_path))
+    vec = np.array([0.4, 0.5, 0.6])
+    store.save_item_embedding("item_1", vec)
+    assert np.allclose(store.get_item_embedding("item_1"), vec)
+
+def test_missing_user_returns_none(tmp_path):
+    store = FeatureStore(store_path=str(tmp_path))
+    assert store.get_user_embedding("unknown_user") is None
+
+def test_missing_item_returns_none(tmp_path):
+    store = FeatureStore(store_path=str(tmp_path))
+    assert store.get_item_embedding("unknown_item") is None


### PR DESCRIPTION
## Summary
Implements a centralized `FeatureStore` class to store and retrieve 
user and item embeddings, so the recommender does not recompute 
them on every request.

## Changes
- Added `src/model/feature_store.py` with `FeatureStore` class
- Added `tests/test_feature_store.py` with 4 unit tests

## How it works
- `save_user_embedding(user_id, embedding)` — saves user vector
- `get_user_embedding(user_id)` — retrieves user vector
- `save_item_embedding(item_id, embedding)` — saves item vector
- `get_item_embedding(item_id)` — retrieves item vector
- Embeddings are persisted to disk using pickle

## Tests
All 4 tests pass:
- save and get user embedding
- save and get item embedding
- missing user returns None
- missing item returns None

Closes #305