### PR TITLE
fix(api): add missing request parameter to get_recommendations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1181,6 +1181,7 @@ def train_federated(req: FederatedTrainRequest):
 @app.get("/api/recommend")
 @app.get("/api/recommend/{item_title}")
 def get_recommendations(
+    request: Request,
     response: Response,
     item_title: Optional[str] = None,
     title: Optional[str] = Query(None),


### PR DESCRIPTION
This PR resolves a FastAPI routing NameError in the recommendation endpoint.

### What Changed
- Added `request: Request` to the routing parameter list of `get_recommendations()` in `backend/main.py`.

### Why
- The handler invoked the rate limiter helper using the `request` object, but it was missing from the FastAPI function signature. This led to a fatal `NameError: name 'request' is not defined` when client requests were made.

### How to Test
1. Compile the backend successfully:
   ```bash
   python3 -m py_compile backend/main.py
   ```
2. Call the `/api/recommend` endpoint and confirm it rate-limits and returns correctly without throwing internal NameErrors.

### Related Issue
Closes #650

---
*I am contributing to this project as part of GirlScript Summer of Code (GSSoC) 2026.*