### PR TITLE
fix: fail closed on missing admin token (#640)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -369,7 +369,10 @@ def _extract_bearer_token(value: str | None) -> str:
 def _require_admin_access(request: Request) -> None:
     expected_token = os.environ.get(ADMIN_API_TOKEN_ENV, "").strip()
     if not expected_token:
-        return
+        raise HTTPException(
+            status_code=500,
+            detail="Admin token not configured.",
+        )
 
     provided_token = (
         request.headers.get("x-admin-token", "").strip()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -222,3 +222,13 @@ def test_dashboard_rejects_invalid_admin_token(client, monkeypatch):
 
     assert res.status_code == 401
     assert res.json()['detail'] == "Admin token required."
+
+
+def test_dashboard_fails_closed_when_admin_token_unset(client, monkeypatch):
+    _patch_supabase(monkeypatch, {'products': [], 'purchases': []})
+    monkeypatch.delenv(backend_main.ADMIN_API_TOKEN_ENV, raising=False)
+
+    res = client.get('/api/dashboard')
+
+    assert res.status_code == 500
+    assert res.json()['detail'] == "Admin token not configured."


### PR DESCRIPTION
### What changed
I refactored the _require_admin_access() helper function in backend/main.py to fail closed rather than failing open. If the ADMIN_API_TOKEN environment variable is unset or empty, the API will now immediately throw an HTTP 500 Internal Server Error instead of silently bypassing the authentication requirement. I also added a regression test in tests/test_dashboard.py to enforce this behavior.

### Why
Previously, if a deployment misconfiguration occurred and the ADMIN_API_TOKEN environment variable was accidentally dropped, the API would silently fail open. This meant that any route relying on the admin helper became completely public. This update prevents accidental config drift from exposing admin-only telemetry, model retraining endpoints, and live data mutations to the public internet.

### How to test
Unset the admin token in your environment (e.g., unset ADMIN_API_TOKEN or remove it from your .env).

Attempt to curl any protected endpoint, such as /api/upload or a dashboard route:

```Bash
curl -X GET http://localhost:8000/api/dashboard \
  -H "X-Admin-Token: whatever"
```
Observe that the endpoint correctly rejects the request with 500 Internal Server Error: Admin token not configured.

Run the newly added unit test:

```Bash
pytest tests/test_dashboard.py -k 'fails_closed_when_admin_token_unset' -v
```

Checklist
- [x] I have read the [CONTRIBUTING.md](https://www.google.com/search?q=CONTRIBUTING.md)

- [x] My code follows PEP8 style (flake8 .)

- [x] I have tested my changes locally

- [x] I have added/updated tests where applicable

- [x] I can explain every line of code I've written

- [x] I have NOT used AI-generated code without understanding and attributing it (See disclosure below)

Related issue
Closes #640 

[x] I used AI assistance for this PR.
I utilized an AI coding assistant (Cursor/Codex) to accelerate the refactoring and test generation. However, I personally identified the vulnerability, directed the architectural fix (fail-closed logic), reviewed the generated Python code for exact adherence to FastAPI standards, and manually verified the test assertions before committing.
- [ ] I used AI assistance for: <!-- describe what -->
