### PR TITLE
fix: remove duplicate route decorator for /api/feedback (#698)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1829,7 +1829,6 @@ def get_trending_products(
 
 # ── Feedback ──────────────────────────────────────────────────────────
 @app.post("/api/feedback")
-@app.post("/api/feedback")
 def submit_feedback(
     data: FeedbackCreate,
     request: Request,


### PR DESCRIPTION
## What changed
Removed one of the two identical `@app.post("/api/feedback")` decorators in `backend/main.py`.

## Why
The duplicate decorator caused redundant route registration. It was unnecessary and could lead to confusion or framework warnings. This fixes issue #698.

## How to test
1. Start the backend:
   ```bash
   python -m uvicorn backend.main:app --reload
    ```
## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #698 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: locating duplicate line
