### PR TITLE
feat: add CSV/JSON export for recommendation results (#25)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -376,6 +376,6 @@
         </div>
     </div>
 </div>
-    <script src="/static/app.js"></script>
+    <script type="module" src="/static/app.js"></script>
 </body>
 </html>

--- a/frontend/js/recommendations.js
+++ b/frontend/js/recommendations.js
@@ -139,6 +139,7 @@ function renderRecommendations(data) {
 
   const recsSection = document.getElementById('recs-section');
   if (recsSection) recsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  injectExportUI(recs);
 }
 
 async function loadRecommendationsOverHttp(title) {
@@ -229,4 +230,64 @@ const API = {
     if (!res.ok) throw new Error(`API error: ${res.status}`);
     return res.json();
   },
+};
+function injectExportUI(recs) {
+  if (document.getElementById('export-controls')) {
+    window._currentRecommendations = recs;
+    return;
+  }
+  const recsSection = document.getElementById('recs-section');
+  if (!recsSection) return;
+  window._currentRecommendations = recs;
+  recsSection.insertAdjacentHTML('afterbegin', `
+    <div id="export-controls" style="display:flex;align-items:center;gap:10px;margin:12px 0 4px;flex-wrap:wrap;">
+      <span style="font-size:13px;color:var(--text-muted);">Export results:</span>
+      <button onclick="exportRecommendations('csv')" style="padding:5px 14px;border:1px solid var(--border);border-radius:4px;background:var(--bg-card);cursor:pointer;font-size:13px;">⬇ CSV</button>
+      <button onclick="exportRecommendations('json')" style="padding:5px 14px;border:1px solid var(--border);border-radius:4px;background:var(--bg-card);cursor:pointer;font-size:13px;">⬇ JSON</button>
+      <span id="export-status" style="font-size:12px;color:var(--text-muted);"></span>
+    </div>
+  `);
+}
+
+window.exportRecommendations = async function(format) {
+  const status = document.getElementById('export-status');
+  const recommendations = (window._currentRecommendations || []).map((r, i) => ({
+    rank: i + 1,
+    title: r.title || '',
+    score: r.hybrid_score || 0,
+    source: r.source || 'hybrid',
+  }));
+
+  if (!recommendations.length) {
+    if (status) status.textContent = '⚠ Nothing to export.';
+    return;
+  }
+  if (status) status.textContent = 'Exporting...';
+  try {
+    const response = await fetch('/api/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format, recommendations }),
+    });
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(err.detail || 'Export failed');
+    }
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const ts = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
+    a.href = url;
+    a.download = `recommendations_${ts}.${format}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    if (status) {
+      status.textContent = `✓ Downloaded!`;
+      setTimeout(() => { status.textContent = ''; }, 3000);
+    }
+  } catch (err) {
+    if (status) status.textContent = `✗ ${err.message}`;
+  }
 };

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,6 +8,13 @@ from dotenv import load_dotenv  # <-- Added
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import Optional
+import csv
+import io
+import json
+from datetime import datetime
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from fastapi.staticfiles import StaticFiles
 
 # Calculate absolute paths and load environment variables first
 CURRENT_DIR = Path(__file__).parent.resolve()
@@ -29,6 +36,7 @@ from src.model.hybrid_model import HybridRecommender
 from src.model.causal_config import CausalConfig
 
 app = FastAPI(title="Hybrid Recommender API")
+app.mount("/static", StaticFiles(directory=str(PROJECT_ROOT / "frontend")), name="static")
 # ===========================================================================
 # NEW: Dynamic Configuration Layout Environment Fetching
 # ===========================================================================
@@ -169,3 +177,56 @@ def get_recommendations(req: RecommendationRequest):
         except Exception as fallback_exc:
             logger.critical(f"Critical System Outage: Fallback engine failed: {str(fallback_exc)}")
             raise HTTPException(status_code=500, detail="Recommendation engine completely offline.")
+
+@app.post("/api/export")
+async def export_recommendations(request: Request):
+    try:
+        body = await request.json()
+        fmt = body.get("format", "csv").lower()
+        recommendations = body.get("recommendations", [])
+
+        if not recommendations:
+            raise HTTPException(status_code=400, detail="No recommendations provided.")
+        if fmt not in ("csv", "json"):
+            raise HTTPException(status_code=400, detail="format must be 'csv' or 'json'.")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"recommendations_{timestamp}.{fmt}"
+
+        if fmt == "csv":
+            output = io.StringIO()
+            writer = csv.DictWriter(
+                output,
+                fieldnames=["rank", "title", "score", "source"],
+                extrasaction="ignore"
+            )
+            writer.writeheader()
+            for i, rec in enumerate(recommendations, start=1):
+                writer.writerow({
+                    "rank": rec.get("rank", i),
+                    "title": rec.get("title", ""),
+                    "score": round(float(rec.get("score", 0)), 4),
+                    "source": rec.get("source", "hybrid"),
+                })
+            output.seek(0)
+            return StreamingResponse(
+                iter([output.getvalue()]),
+                media_type="text/csv",
+                headers={"Content-Disposition": f"attachment; filename={filename}"}
+            )
+        else:
+            export_data = {
+                "exported_at": datetime.now().isoformat(),
+                "count": len(recommendations),
+                "recommendations": recommendations
+            }
+            json_bytes = json.dumps(export_data, indent=2).encode("utf-8")
+            return StreamingResponse(
+                iter([json_bytes]),
+                media_type="application/json",
+                headers={"Content-Disposition": f"attachment; filename={filename}"}
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Export failed: {str(e)}")


### PR DESCRIPTION
Closes #25

## What changed
- Added `/api/export` POST endpoint in `src/api/main.py` supporting CSV and JSON format
- CSV includes headers: rank, title, score, source
- JSON includes full recommendation array with metadata and timestamp
- Added export buttons to frontend via `frontend/js/recommendations.js`
- Files are named `recommendations_<timestamp>.<ext>`

## Why
Users need to save, analyze, or share recommendations outside the app. This adds CSV and JSON download functionality as described in issue #25.

## How to test
```bash
curl -X POST http://127.0.0.1:8000/api/export \
  -H "Content-Type: application/json" \
  -d '{"format":"csv","recommendations":[{"rank":1,"title":"Test","score":0.95,"source":"hybrid"}]}'
```

## Screenshots
Tested via curl — CSV and JSON both return correct data with timestamped filenames.