### PR TITLE
fix: remove stray characters from recommend method

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -380,9 +380,7 @@ class HybridRecommender:
         sentiment_scores = self._normalize_scores(sentiment_raws)
 
         kg_scores = []
-        t
         if self.kg_model:
-            l
             kg_recs = self.kg_model.recommend(title, top_n=top_n * 3)
            
             kg_map = {


### PR DESCRIPTION
## What changed

- Removed stray standalone expressions (t and l) from the recommend() method in hybrid_model.py.
- Preserved the existing recommendation logic without modifying behavior.

## Why
The stray expressions could trigger runtime NameError exceptions when executed. They appear to be accidental characters left in the source code and do not contribute to application logic.

## How to test
Verify syntax 
python -m py_compile hybrid_model.py 

Run recommendation workflow or project tests 
python test_pipeline.py

## Screenshots (if UI change)
N/A – backend logic cleanup only.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #781 

## AI assistance disclosure

- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: reviewing the reported issue, and improving PR description.
