### PR TITLE
fix : add upper-bound validation to n_factors in ModelHyperparametersSchema

### DIFF
--- a/src/model/schemas.py
+++ b/src/model/schemas.py
@@ -2,7 +2,7 @@
 Validation schemas and parameter contracts for the recommendation models.
 Enforces strict type checking, bounds, and defaults using Pydantic.
 """
-from typing import Optional, Dict, Any
+
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -11,8 +11,16 @@ class ModelHyperparametersSchema(BaseModel):
     Strict configuration validation schema contract for model hyperparameters.
     Ensures structural parameters conform to training requirements.
     """
-    n_factors: int = Field(default=50, ge=1, description="Number of latent factors for SVD matrix factorization.")
-    use_implicit: bool = Field(default=True, description="Whether to treat interactions implicitly.")
+
+    n_factors: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description="Number of latent factors for SVD matrix factorization.",
+    )
+    use_implicit: bool = Field(
+        default=True, description="Whether to treat interactions implicitly."
+    )
 
     class Config:
         frozen = True
@@ -24,16 +32,35 @@ class HybridWeightsSchema(BaseModel):
     Strict parameter verification schema contract for hybrid blending weights.
     Validates type bounds and dynamically enforces normalization limits.
     """
-    alpha: float = Field(default=0.4, ge=0.0, le=1.0, description="Weight for content-based score blending component.")
-    beta: float = Field(default=0.35, ge=0.0, le=1.0, description="Weight for collaborative filtering score blending component.")
-    gamma: float = Field(default=0.25, ge=0.0, le=1.0, description="Weight for NLP sentiment score blending component.")
+
+    alpha: float = Field(
+        default=0.4,
+        ge=0.0,
+        le=1.0,
+        description="Weight for content-based score blending component.",
+    )
+    beta: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Weight for collaborative filtering score blending component.",
+    )
+    gamma: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description="Weight for NLP sentiment score blending component.",
+    )
 
     @model_validator(mode="after")
     def validate_weights_normalization(self) -> "HybridWeightsSchema":
         """Ensures that blending parameters don't break normalization baselines."""
         total = self.alpha + self.beta + self.gamma
         if total <= 0.0:
-            raise ValueError("The cumulative summation of blending weights (alpha, beta, gamma) must be greater than 0.")
+            raise ValueError(
+                "The cumulative summation of blending weights "
+                "(alpha, beta, gamma) must be greater than 0."
+            )
         return self
 
     class Config:


### PR DESCRIPTION
Refs #799.

Summary of What Has Been Done:
Added upper bound constraint (le=500) to the n_factors Field in src/model/schemas.py. Previously n_factors only had ge=1 (minimum 1) with no upper bound. The new constraint prevents accidental configuration with extremely large n_factors values that could cause OOM errors or very slow training times.

Changes Made:
- Modified src/model/schemas.py, ModelHyperparametersSchema.n_factors Field
- Added le=500 constraint to prevent excessive memory allocation
- Reformatted file to comply with line length limits (100 chars)

Impact it Made:
Acts as a safety guard for production configurations, preventing OOM errors from misconfigured SVD matrix factorization parameters.