### PR TITLE
fix(hybrid): remove stray orphaned single-char tokens 't' and 'l' in …

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -380,11 +380,9 @@ class HybridRecommender:
         sentiment_scores = self._normalize_scores(sentiment_raws)
 
         kg_scores = []
-        t
         if self.kg_model:
-            l
             kg_recs = self.kg_model.recommend(title, top_n=top_n * 3)
-           
+
             kg_map = {
                 item['title']: item['kg_score']
                 for item in kg_recs
@@ -397,6 +395,7 @@ class HybridRecommender:
 
         else:
             kg_scores = [0.0] * len(items)
+
 
         
 


### PR DESCRIPTION
…recommend()

Two bare expression statements — a lone 	 and a lone l — were left in the HybridRecommender.recommend() method body after a bad merge or rebase conflict resolution.  They are valid Python expressions (name lookups) but have absolutely no effect at runtime; however:

  - Any linter (flake8, pylint, ruff) flags them as unused expressions.
  - They make the intent of the surrounding knowledge-graph block unclear.
  - They indicate that meaningful code (likely 	ry / logger.debug or similar) was accidentally deleted during conflict resolution.

Remove both stray tokens to restore clean, readable control flow.

## What changed
<!-- Describe what you added, fixed, or changed -->

## Why
<!-- Explain the problem this solves or the feature this adds -->

## How to test
<!-- Step-by-step instructions to test your changes locally -->
```bash
# Example:
pip install -r requirements.txt
python test_pipeline.py
```

## Screenshots (if UI change)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I can explain every line of code I've written
- [ ] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #866 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
