### PR TITLE
fix(security): resolve prototype pollution vulnerability in preferenc…

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -192,6 +192,29 @@ const CONFIG = {
   MAX_COMPARE_ITEMS: 20
 };
 
+/**
+ * Securely merges objects to prevent prototype pollution.
+ */
+function safeMerge(target, source) {
+    for (const key in source) {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
+        const sourceVal = source[key];
+        const targetVal = target[key];
+
+        if (typeof sourceVal === 'object' && sourceVal !== null && !Array.isArray(sourceVal)) {
+            if (typeof targetVal !== 'object' || targetVal === null || Array.isArray(targetVal)) {
+                target[key] = {};
+            }
+            safeMerge(target[key], sourceVal);
+        } else {
+            target[key] = sourceVal;
+        }
+    }
+    return target;
+}
+
 function loadPreferences() {
     const saved = localStorage.getItem('userPreferences');
 
@@ -200,13 +223,12 @@ function loadPreferences() {
     try {
         const prefs = JSON.parse(saved);
 
-        state.filters.category = prefs.category || '';
-        state.filters.rating = prefs.rating || '';
-        state.filters.sentiment = prefs.sentiment || '';
+        // Safely merge parsed preferences into state.filters
+        safeMerge(state.filters, prefs);
 
-        els.categoryFilter.value = state.filters.category;
-        els.ratingFilter.value = state.filters.rating;
-        els.sentimentFilter.value = state.filters.sentiment;
+        els.categoryFilter.value = state.filters.category || '';
+        els.ratingFilter.value = state.filters.rating || '';
+        els.sentimentFilter.value = state.filters.sentiment || '';
 
     } catch (err) {
         console.warn('Failed to load preferences:', err);

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -29,3 +29,28 @@ export function isSafeRedirect(url) {
         return false;
     }
 }
+/**
+ * Securely merges objects to prevent prototype pollution.
+ * @param {Object} target
+ * @param {Object} source
+ * @returns {Object}
+ */
+export function safeMerge(target, source) {
+    for (const key in source) {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
+        const sourceVal = source[key];
+        const targetVal = target[key];
+
+        if (typeof sourceVal === 'object' && sourceVal !== null && !Array.isArray(sourceVal)) {
+            if (typeof targetVal !== 'object' || targetVal === null || Array.isArray(targetVal)) {
+                target[key] = {};
+            }
+            safeMerge(target[key], sourceVal);
+        } else {
+            target[key] = sourceVal;
+        }
+    }
+    return target;
+}

--- a/tests/test_safe_merge.js
+++ b/tests/test_safe_merge.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+
+// Simulate the safeMerge function to test its logic
+function safeMerge(target, source) {
+    for (const key in source) {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
+        const sourceVal = source[key];
+        const targetVal = target[key];
+
+        if (typeof sourceVal === 'object' && sourceVal !== null && !Array.isArray(sourceVal)) {
+            if (typeof targetVal !== 'object' || targetVal === null || Array.isArray(targetVal)) {
+                target[key] = {};
+            }
+            safeMerge(target[key], sourceVal);
+        } else {
+            target[key] = sourceVal;
+        }
+    }
+    return target;
+}
+
+console.log("Running safeMerge tests...");
+
+// Test 1: Basic merging
+let target1 = { a: 1, b: { c: 2 } };
+let source1 = { b: { d: 3 }, e: 4 };
+let result1 = safeMerge(target1, source1);
+assert.deepStrictEqual(result1, { a: 1, b: { c: 2, d: 3 }, e: 4 }, "Basic merge failed");
+console.log("✓ Basic merge passed");
+
+// Test 2: Prototype Pollution via __proto__
+let target2 = {};
+let maliciousPayload1 = JSON.parse('{"__proto__": {"polluted": true}}');
+safeMerge(target2, maliciousPayload1);
+assert.strictEqual({}.polluted, undefined, "Prototype polluted via __proto__!");
+console.log("✓ Prototype pollution blocked (__proto__)");
+
+// Test 3: Prototype Pollution via constructor.prototype
+let target3 = {};
+let maliciousPayload2 = JSON.parse('{"constructor": {"prototype": {"polluted2": true}}}');
+safeMerge(target3, maliciousPayload2);
+assert.strictEqual({}.polluted2, undefined, "Prototype polluted via constructor!");
+console.log("✓ Prototype pollution blocked (constructor.prototype)");
+
+// Test 4: Existing fields overwritten safely
+let target4 = { category: "Electronics" };
+let source4 = { category: "Books" };
+let result4 = safeMerge(target4, source4);
+assert.strictEqual(result4.category, "Books", "Failed to overwrite property safely");
+console.log("✓ Overwriting existing property passed");
+
+console.log("All tests passed securely!");


### PR DESCRIPTION
## What changed

- Implemented a custom `safeMerge` utility function to securely deep-merge preference objects.
- Updated the `loadPreferences` logic in `frontend/app.js` to utilize `safeMerge` instead of naive parsing/assignment, thereby sanitizing any polluted input.
- Added a security-focused Node.js test script (`tests/test_safe_merge.js`) to explicitly validate that `__proto__` and `constructor.prototype` keys are successfully ignored and dropped.

## Why

This resolves the prototype pollution vulnerability reported in Issue #308, ensuring that malicious configurations loaded from local storage cannot pollute the global object prototype.

## How to test

```bash
# Run the newly added security validation tests:
node tests/test_safe_merge.js
```

The output should clearly display:

```text
✓ Basic merge passed
✓ Prototype pollution blocked (__proto__)
✓ Prototype pollution blocked (constructor.prototype)

All tests passed securely!
```

## Screenshots (if UI change)

N/A

## Checklist

- [x] I have read the `CONTRIBUTING.md`
- [x] My code follows PEP8 style (`flake8 .`) (N/A for JS files)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue

Closes #308

## AI assistance disclosure

- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for:
  - Writing the `safeMerge` recursive implementation to block prototype pollution keys.
  - Authoring the security test cases.