### PR TITLE
Fix hybrid recommendation collaborative candidate regression

### DIFF
--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -135,9 +135,7 @@ class ContentRecommender:
                 'top_reviews': top_reviews,
             })
 
-        return results
-
             if len(results) >= top_n:
                 break
-        return results
 
+        return results

--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -34,7 +34,7 @@ class HybridRecommender:
                  alpha=0.4, beta=0.35, gamma=0.25,
                  normalization='minmax', weight_matrix=None,
                  use_causal_debiasing=False, causal_lambda=0.5, causal_clip=5.0,
-                 causal_config=None):
+                 causal_config=None, model_kwargs=None):
         """
         content_model:        ContentRecommender instance
         collab_model:         CollaborativeRecommender instance (optional)
@@ -100,6 +100,10 @@ class HybridRecommender:
                 else None
             )
             self._causal_config = None
+
+        self.fairness_enabled = False
+        self.fairness_key = 'category'
+        self.fairness_max_share = 1.0
 
         # Build sentiment + rating lookups
         self._sentiment_map = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -191,6 +191,31 @@ class TestHybridRecommender:
         recs = hybrid_model.recommend('Product A', top_n=3)
         assert isinstance(recs, list)
 
+    def test_recommend_merges_collaborative_only_candidates(self, sample_item_df):
+        """Collaborative-only candidates should be merged without all_titles errors."""
+        class ContentStub:
+            def __init__(self, df):
+                self.df = df
+
+            def recommend(self, title, top_n=10, target_catalog=None):
+                return [{'title': 'Product B', 'content_score': 0.9}]
+
+        class CollaborativeStub:
+            def recommend(self, title, top_n=10, target_catalog=None):
+                return [{'title': 'Product C', 'collab_score': 0.8}]
+
+        recommender = HybridRecommender(
+            ContentStub(sample_item_df),
+            CollaborativeStub(),
+            sample_item_df,
+        )
+
+        recs = recommender.recommend('Product A', top_n=5)
+        titles = {rec['title'] for rec in recs}
+
+        assert 'Product B' in titles
+        assert 'Product C' in titles
+
     def test_recommend_has_required_keys(self, hybrid_model):
         recs = hybrid_model.recommend('Product A', top_n=2)
         required = {'title', 'hybrid_score', 'content_score', 'collab_score', 'sentiment_score'}


### PR DESCRIPTION
## Summary

- Added a regression test for `HybridRecommender.recommend()` with collaborative-only candidates.
- Ensured fresh `HybridRecommender` instances initialize optional constructor/fairness defaults.
- Fixed a small `ContentRecommender.search()` indentation issue that blocked model test collection.

Fixes #947.

## Validation

- `tests/test_models.py`: 36 passed
- `py_compile` on changed Python files
- `git diff --check`