### PR TITLE
Added model readiness diagnostics endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -489,6 +489,18 @@ STAGING_MODEL_VERSION = None
 
 SHADOW_LOGS = []
 
+MODEL_DATASET_IMPORTANT_COLUMNS = (
+    "id",
+    "title",
+    "description",
+    "category",
+    "rating",
+    "review_count",
+    "avg_sentiment",
+    "combined",
+)
+
+
 def generate_model_version():
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     return f"1.0.0-{timestamp}"
@@ -649,7 +661,128 @@ def status():
     }
 
 
-# ── Dashboard ─────────────────────────────────────────────────────────
+# Model readiness diagnostics
+def _get_component_readiness():
+    return {
+        "content": models.get("content") is not None,
+        "collab": models.get("collab") is not None,
+        "hybrid": models.get("hybrid") is not None,
+        "item_df": models.get("item_df") is not None,
+    }
+
+
+def _get_dataset_readiness(item_df):
+    diagnostics = {
+        "available": item_df is not None,
+        "shape": {"rows": 0, "columns": 0},
+        "columns": [],
+        "important_columns": {
+            column: False for column in MODEL_DATASET_IMPORTANT_COLUMNS
+        },
+    }
+
+    if item_df is None:
+        return diagnostics
+
+    try:
+        rows, columns_count = item_df.shape
+        diagnostics["shape"] = {
+            "rows": int(rows),
+            "columns": int(columns_count),
+        }
+    except (AttributeError, TypeError, ValueError):
+        diagnostics["available"] = False
+        return diagnostics
+
+    try:
+        columns = [str(column) for column in item_df.columns]
+    except AttributeError:
+        diagnostics["available"] = False
+        return diagnostics
+
+    available_columns = set(columns)
+    diagnostics["columns"] = columns
+    diagnostics["important_columns"] = {
+        column: column in available_columns
+        for column in MODEL_DATASET_IMPORTANT_COLUMNS
+    }
+    return diagnostics
+
+
+def _get_hybrid_weights(hybrid_model, warnings):
+    if hybrid_model is None:
+        return None
+
+    if not hasattr(hybrid_model, "get_weights"):
+        warnings.append("Hybrid model is loaded but does not expose weights.")
+        return None
+
+    try:
+        weights = hybrid_model.get_weights()
+        return dict(weights) if weights is not None else None
+    except Exception as exc:
+        logger.warning("Unable to read hybrid model weights: %s", exc)
+        warnings.append("Hybrid model weights could not be read.")
+        return None
+
+
+def _get_model_readiness_warnings(is_ready, components, dataset):
+    warnings = []
+
+    if not is_ready:
+        warnings.append("Models have not been built yet.")
+
+    missing_components = [
+        name for name, available in components.items() if not available
+    ]
+    if is_ready and missing_components:
+        warnings.append(
+            "Model state is marked ready but missing components: "
+            + ", ".join(missing_components)
+            + "."
+        )
+    elif any(components.values()) and missing_components:
+        warnings.append(
+            "Partial model readiness detected; missing components: "
+            + ", ".join(missing_components)
+            + "."
+        )
+
+    missing_columns = [
+        column
+        for column, present in dataset["important_columns"].items()
+        if not present
+    ]
+    if components["item_df"] and missing_columns:
+        warnings.append(
+            "Item dataset is missing important columns: "
+            + ", ".join(missing_columns)
+            + "."
+        )
+
+    return warnings
+
+
+@app.get("/api/model-readiness")
+def model_readiness():
+    components = _get_component_readiness()
+    dataset = _get_dataset_readiness(models.get("item_df"))
+    is_ready = bool(models.get("ready"))
+    warnings = _get_model_readiness_warnings(is_ready, components, dataset)
+    weights = _get_hybrid_weights(models.get("hybrid"), warnings)
+
+    return {
+        "ready": is_ready,
+        "active_model_version": ACTIVE_MODEL_VERSION,
+        "last_trained_at": models.get("last_trained_at"),
+        "components": components,
+        "dataset": dataset,
+        "weights": weights,
+        "warnings": warnings,
+    }
+
+
+# Dashboard
 @app.get("/api/dashboard")
 def dashboard(request: Request):
     _require_admin_access(request)

--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -135,9 +135,7 @@ class ContentRecommender:
                 'top_reviews': top_reviews,
             })
 
-        return results
-
             if len(results) >= top_n:
                 break
-        return results
 
+        return results

--- a/tests/test_model_readiness.py
+++ b/tests/test_model_readiness.py
@@ -1,0 +1,201 @@
+import os
+import sys
+import types
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+nlp_engine_stub = types.ModuleType("src.model.nlp_engine")
+nlp_engine_stub.batch_analyze = lambda df, text_col="review_text": df
+nlp_engine_stub.aggregate_sentiment_by_item = (
+    lambda df, item_col="title": pd.DataFrame(
+        {item_col: [], "avg_sentiment": [], "review_count": []}
+    )
+)
+sys.modules.setdefault("src.model.nlp_engine", nlp_engine_stub)
+
+from backend import main
+
+
+class FakeHybridModel:
+    def get_weights(self):
+        return {"content": 0.5, "collaborative": 0.3, "sentiment": 0.2}
+
+
+def complete_item_df():
+    item_df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "title": ["Alpha", "Beta"],
+            "description": ["Noise cancelling headphones", "Desk stand"],
+            "category": ["Audio", "Accessories"],
+            "rating": [4.7, 4.2],
+            "review_count": [120, 80],
+            "avg_sentiment": [0.7, 0.4],
+        }
+    )
+    item_df["combined"] = (
+        item_df["title"] + " " + item_df["description"] + " " + item_df["category"]
+    )
+    return item_df
+
+
+@pytest.fixture
+def readiness_client():
+    previous_models = main.models.copy()
+    previous_active_model_version = main.ACTIVE_MODEL_VERSION
+    main.models.update(
+        {
+            "content": None,
+            "collab": None,
+            "hybrid": None,
+            "ready": False,
+            "item_df": None,
+            "build_time": None,
+            "last_trained_at": None,
+        }
+    )
+    main.ACTIVE_MODEL_VERSION = None
+
+    try:
+        yield TestClient(main.app)
+    finally:
+        main.models.clear()
+        main.models.update(previous_models)
+        main.ACTIVE_MODEL_VERSION = previous_active_model_version
+
+
+def test_model_readiness_reports_models_not_built(readiness_client):
+    response = readiness_client.get("/api/model-readiness")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["active_model_version"] is None
+    assert payload["last_trained_at"] is None
+    assert payload["components"] == {
+        "content": False,
+        "collab": False,
+        "hybrid": False,
+        "item_df": False,
+    }
+    assert payload["dataset"]["available"] is False
+    assert payload["dataset"]["shape"] == {"rows": 0, "columns": 0}
+    assert payload["weights"] is None
+    assert "Models have not been built yet." in payload["warnings"]
+
+
+def test_model_readiness_reports_content_only_partial_readiness(readiness_client):
+    main.models.update(
+        {
+            "content": object(),
+            "item_df": complete_item_df(),
+            "ready": True,
+            "last_trained_at": "2026-06-01T10:00:00+00:00",
+        }
+    )
+
+    response = readiness_client.get("/api/model-readiness")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is True
+    assert payload["components"] == {
+        "content": True,
+        "collab": False,
+        "hybrid": False,
+        "item_df": True,
+    }
+    assert payload["dataset"]["available"] is True
+    assert payload["dataset"]["shape"] == {"rows": 2, "columns": 8}
+    assert all(payload["dataset"]["important_columns"].values())
+    assert payload["weights"] is None
+    assert any(
+        "missing components: collab, hybrid" in warning
+        for warning in payload["warnings"]
+    )
+
+
+def test_model_readiness_reports_full_hybrid_readiness(readiness_client):
+    main.ACTIVE_MODEL_VERSION = "1.0.0-20260601100000"
+    main.models.update(
+        {
+            "content": object(),
+            "collab": object(),
+            "hybrid": FakeHybridModel(),
+            "item_df": complete_item_df(),
+            "ready": True,
+            "last_trained_at": "2026-06-01T10:00:00+00:00",
+        }
+    )
+
+    response = readiness_client.get("/api/model-readiness")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is True
+    assert payload["active_model_version"] == "1.0.0-20260601100000"
+    assert payload["last_trained_at"] == "2026-06-01T10:00:00+00:00"
+    assert payload["components"] == {
+        "content": True,
+        "collab": True,
+        "hybrid": True,
+        "item_df": True,
+    }
+    assert payload["weights"] == {
+        "content": 0.5,
+        "collaborative": 0.3,
+        "sentiment": 0.2,
+    }
+    assert payload["warnings"] == []
+
+
+def test_model_readiness_warns_when_ready_state_is_missing_dataset(readiness_client):
+    main.models.update(
+        {
+            "content": object(),
+            "collab": object(),
+            "hybrid": FakeHybridModel(),
+            "ready": True,
+        }
+    )
+
+    response = readiness_client.get("/api/model-readiness")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["components"]["item_df"] is False
+    assert payload["dataset"]["available"] is False
+    assert payload["weights"] == {
+        "content": 0.5,
+        "collaborative": 0.3,
+        "sentiment": 0.2,
+    }
+    assert any("missing components: item_df" in warning for warning in payload["warnings"])
+
+
+def test_model_readiness_warns_for_missing_important_dataset_columns(readiness_client):
+    main.models.update(
+        {
+            "content": object(),
+            "collab": object(),
+            "hybrid": FakeHybridModel(),
+            "item_df": pd.DataFrame({"title": ["Alpha"], "rating": [4.7]}),
+            "ready": True,
+        }
+    )
+
+    response = readiness_client.get("/api/model-readiness")
+
+    assert response.status_code == 200
+    payload = response.json()
+    important_columns = payload["dataset"]["important_columns"]
+    assert important_columns["id"] is False
+    assert important_columns["title"] is True
+    assert important_columns["rating"] is True
+    assert important_columns["description"] is False
+    assert important_columns["combined"] is False
+    assert any("missing important columns" in warning for warning in payload["warnings"])


### PR DESCRIPTION
## What changed
Added a public `/api/model-readiness` endpoint that reports model readiness, component availability, active model version, last trained timestamp, dataset diagnostics, hybrid weights, and warnings for partial readiness.

Also added focused API tests for unbuilt, content-only, full hybrid, missing dataset, and missing column readiness states.

## Why
This gives frontend and monitoring clients a safe way to inspect whether the recommender system is fully ready without exposing admin-only data or secrets.

## How to test
```bash
PYTHONPATH=C:\tmp\hybrid-recommender-test-stubs python -m pytest tests/test_model_readiness.py -q
python -m py_compile backend/main.py src/model/content_model.py tests/test_model_readiness.py
git diff --check
```


## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [ ] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #948 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x] I used AI assistance for: implementing the endpoint, adding tests, and validating the changes locally.

