### PR TITLE
Add theme-color meta tag to frontend/index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,12 +11,7 @@
     <link rel="manifest" href="./site.webmanifest">
 
     <meta name="description" content="HybridRec — AI-powered product recommendations using content, collaborative, and sentiment analysis.">
-    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
-
-    <meta property="og:title" content="HybridRec — Hybrid Recommender System" />
-    <meta property="og:description" content="A hybrid recommender fusing TF-IDF, SVD, and VADER sentiment analysis to deliver personalised product recommendations." />
-    <meta property="og:type" content="website" />
-
+    <meta name="theme-color" content="#0f1923">
     <title>HybridRec — Smart Recommendations</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Sets the browser chrome color to match the dark header (#0f1923) for a more native app-like experience on mobile and desktop.