### PR TITLE
fix: replace silent except pass blocks with logger warnings in hybrid_model.py

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -270,8 +270,8 @@ class HybridRecommender:
                     key = f'category:{top_cat}'
                     if key in self.weight_matrix:
                         a, b, g = self.weight_matrix[key]
-            except Exception as e:
-                logger.warning(f"Weight resolution failed for category signal: {e}")    
+        except Exception as e:
+            logger.warning(f"Weight resolution failed for category signal: {e}")    
 
         # user signals
         if user_id and self.collab_model and hasattr(self.collab_model, 'df'):

--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -16,7 +16,8 @@ import numpy as np
 
 from src.model.causal_config import CausalConfig
 from src.model.causal_model import CausalDebiaser
-
+import logging
+logger = logging.getLogger(__name__)
 
 def bayesian_rating(rating, review_count, global_avg=3.0, min_votes=10):
     """
@@ -269,8 +270,8 @@ class HybridRecommender:
                     key = f'category:{top_cat}'
                     if key in self.weight_matrix:
                         a, b, g = self.weight_matrix[key]
-        except Exception:
-            pass
+            except Exception as e:
+                logger.warning(f"Weight resolution failed for category signal: {e}")    
 
         # user signals
         if user_id and self.collab_model and hasattr(self.collab_model, 'df'):
@@ -280,8 +281,9 @@ class HybridRecommender:
                     a, b, g = self.weight_matrix['warm_user']
                 if 'cold_user' in self.weight_matrix and user_interacts < 3:
                     a, b, g = self.weight_matrix['cold_user']
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Weight resolution failed for user signal: {e}")
+
 
         # feature absence overrides
         if self.collab_model is None and 'no_collab' in self.weight_matrix:


### PR DESCRIPTION
## What changed
- Added `import logging` and `logger = logging.getLogger(__name__)` to `src/model/hybrid_model.py`
- Replaced two silent `except Exception: pass` blocks in `_resolve_weights` with `logger.warning()` calls that provide context about what failed

## Why
Silent exception handling was making it impossible to debug weight resolution failures. The recommender could silently return wrong results with no indication of what went wrong.

## How to test
Trigger weight resolution with invalid data and check that a warning is logged instead of the error being silently swallowed.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I can explain every line of code I've written
- [ ] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #950

## AI assistance disclosure
- [x] I used AI assistance for: understanding the codebase and identifying the fix location
