### PR TITLE
Refactor LabelEncoder usage in data preprocessing

### DIFF
--- a/src/data/data_preprocessing.py
+++ b/src/data/data_preprocessing.py
@@ -41,10 +41,9 @@ def encode_categorical(
         add_suffix = True
     else:
         add_suffix = False
-    le = LabelEncoder()
     for col in columns:
         if col in df.columns:
-            encoded_val = le.fit_transform(df[col].astype(str))
+            encoded_val = LabelEncoder().fit_transform(df[col].astype(str))
             if add_suffix:
                 df[f'{col}_encoded'] = encoded_val
             else:


### PR DESCRIPTION
Fixes a silent data bug in `data_preprocessing.py` where a single `LabelEncoder`
instance was reused across all categorical columns, causing each `fit_transform()`
to overwrite the previous column's class mapping.

## Screenshots (if UI change)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ x] My code follows PEP8 style (`flake8 .`)
- [ x] I have tested my changes locally
- [ x] I have added/updated tests where applicable
- [ x] I can explain every line of code I've written
- [ x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #873 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [x ] I used AI assistance for:to know the bug
