### PR TITLE
fix: detect description column in data adapter

### DIFF
--- a/src/data/data_adapter.py
+++ b/src/data/data_adapter.py
@@ -399,9 +399,14 @@ def adapt_data(df):
 
     desc_col = detect_column(
         columns,
-        ['desc', 'summary', 'overview', 'about']
+        [
+            'description',
+            'desc',
+            'summary',
+            'overview',
+            'about'
+        ]
     )
-
     user_col = detect_column(
         columns,
         ['user_id', 'user', 'reviewer', 'customer']


### PR DESCRIPTION
## Summary

Fixes an issue where CSV files using the standard `description` column name were not correctly detected by the data adapter.

## Problem

The description column detection logic did not explicitly include `description` in its list of supported aliases. As a result, product descriptions could be ignored when processing CSV files that used the full `description` header.

This caused product descriptions to be populated with empty strings, reducing the effectiveness of the TF-IDF content-based recommendation model.

## Changes Made

* Added explicit support for the `description` column name in the description detection logic.
* Preserved support for existing aliases such as `desc`, `summary`, `overview`, and `about`.

## Result

CSV files containing a `description` column are now processed correctly, ensuring that product descriptions are available for recommendation generation and improving recommendation quality.

close #875 