### PR TITLE
fix: disable CORS credentials when origins contain wildcard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -491,10 +491,14 @@ def _get_feedback_storage_client():
 allowed_origins_env = os.environ.get("CORS_ORIGINS", "http://localhost:8000,http://127.0.0.1:8000")
 allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",")]
 
+allow_creds = True
+if "*" in allowed_origins:
+    allow_creds = False
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
-    allow_credentials=True,
+    allow_credentials=allow_creds,
     allow_methods=["*"],
     allow_headers=["*", "X-CSRF-Token"],
 )


### PR DESCRIPTION
When `allow_credentials=True` is combined with `allow_origins=[*]`, browsers reject the credentials. Added a guard that disables credentials if wildcard origins are detected, preventing the insecure configuration and silent CORS failures.