### PR TITLE
fix: remove continue-on-error from CI workflow to enforce strict failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         run: pip install flake8
 
       - name: Run flake8
-        continue-on-error: true
         run: |
           flake8 . \
             --exclude=datasets/,frontend/,scripts/,assets/,tests/ \
@@ -58,7 +57,6 @@ jobs:
           python -c "import nltk; nltk.download('vader_lexicon')"
 
       - name: Run smoke test
-        continue-on-error: true
         run: python test_pipeline.py
         env:
           SUPABASE_URL: "https://placeholder.supabase.co"


### PR DESCRIPTION
Both the flake8 lint step and the smoke-test step had continue-on-error: true, which allowed failing checks to pass silently. Removed these so CI accurately reflects pipeline health.