### PR TITLE
fix: remove unused numpy import in nlp_engine.py

### DIFF
--- a/src/model/nlp_engine.py
+++ b/src/model/nlp_engine.py
@@ -4,7 +4,6 @@ Uses NLTK VADER for lightweight sentiment analysis on user review text.
 """
 import nltk
 import pandas as pd
-import numpy as np
 
 # Download VADER lexicon (only on first run)
 try:


### PR DESCRIPTION
numpy is imported but never used in src/model/nlp_engine.py