### PR TITLE
fix: remove unused imports in federated_learning.py

### DIFF
--- a/src/model/federated_learning.py
+++ b/src/model/federated_learning.py
@@ -6,8 +6,6 @@ across decentralized client nodes without centralizing raw user interactions.
 
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix
-from sklearn.decomposition import TruncatedSVD
 from src.model.collaborative_model import CollaborativeRecommender
 
 


### PR DESCRIPTION
csr_matrix and TruncatedSVD are imported but never used in the file