### PR TITLE
fix: remove unused os import in two_tower_retrieval.py

### DIFF
--- a/src/model/two_tower_retrieval.py
+++ b/src/model/two_tower_retrieval.py
@@ -2,7 +2,6 @@
 Two-Tower Neural Retrieval Model for Scalable Candidate Generation.
 Uses dual encoders for users and items, indexed via FAISS for sub-10ms retrieval.
 """
-import os
 import numpy as np
 import pandas as pd
 import torch


### PR DESCRIPTION
os is imported but never used anywhere in the file