### PR TITLE
fix: remove unused field import in causal_config.py

### DIFF
--- a/src/model/causal_config.py
+++ b/src/model/causal_config.py
@@ -31,7 +31,7 @@ Design notes
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass

--- a/src/model/causal_config.py
+++ b/src/model/causal_config.py
@@ -29,7 +29,7 @@ Design notes
   propagate silently into numpy operations.
 """
 
-from __future__ import annotations
+from dataclasses import dataclass, field
 
 from dataclasses import dataclass
 


### PR DESCRIPTION
field is imported from dataclasses but never used