### PR TITLE
fix: add pytest-env dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ streamlit>=1.28.0
 celery>=5.3.6
 redis>=5.0.1
 python-dotenv>=1.0.1
+pytest-env>=1.1.3


### PR DESCRIPTION
Closes #916

## What changed
- Added `pytest-env` to `requirements.txt` so the existing `pytest.ini` `env = TESTING=true` setting is recognized on clean installs.

## Why
Without the plugin installed, pytest ignores the `env` block and reports `PytestConfigWarning: Unknown config option: env`. That means `TESTING=true` is not reliably set for contributors or CI environments that install only the declared project dependencies.

## How to test
- Reproduced the warning with the current system Python environment where `pytest-env` was not installed:
  - `python3 -m pytest tests/test_request_model_extras.py -q`
- Created a temporary clean venv and installed `pytest` plus the new `pytest-env` dependency.
- Verified the repo `pytest.ini` loads the plugin and injects `TESTING=true`:
  - `/tmp/hybrid-pytest-env-venv/bin/python -m pytest -q -c pytest.ini /tmp/test_pytest_env_config.py`
  - Result: `1 passed`, plugin shown as `env-1.6.0`

Note: the broader local test command still hits an unrelated upstream `IndentationError` in `backend/main.py` at line 2108 during collection. This PR only fixes the missing pytest plugin declaration.

## GSSoC
Raised and implemented as part of GSSoC 2026. Please add the relevant GSSoC label for points tracking if it is not applied automatically.
