### PR TITLE
feat: Implement approximate nearest neighbor search using HNSW index

### DIFF
--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -11,6 +11,12 @@ import pandas as pd
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
 
+# Optional HNSW support (enabled only if hnswlib is importable)
+try:
+    import hnswlib
+except Exception:
+    hnswlib = None
+
 
 class ContentRecommender:
     def __init__(self, item_df, model_name='all-MiniLM-L6-v2', batch_size=256):
@@ -35,6 +41,27 @@ class ContentRecommender:
         # Stack slices cleanly into a single final continuous array allocation
         self.matrix = np.vstack(embeddings_list) if embeddings_list else np.empty((0, 0))
         
+        # Internal ANN attributes (built automatically if hnswlib available)
+        self._ann_index = None
+        self._ann_enabled = False
+
+        # Build HNSW index automatically if hnswlib is importable and embeddings exist
+        try:
+            if hnswlib is not None and getattr(self, 'matrix', None) is not None and self.matrix.size and self.matrix.shape[0] > 0:
+                dim = int(self.matrix.shape[1])
+                num_elements = int(self.matrix.shape[0])
+                index = hnswlib.Index(space='cosine', dim=dim)
+                index.init_index(max_elements=num_elements, ef_construction=200, M=16)
+                # hnswlib expects float32 vectors; cast to reduce memory and ensure compatibility
+                index.add_items(self.matrix.astype(np.float32), np.arange(num_elements))
+                index.set_ef(50)
+                self._ann_index = index
+                self._ann_enabled = True
+        except Exception:
+            # Fail-open: silently disable ANN and continue using brute-force
+            self._ann_index = None
+            self._ann_enabled = False
+
         self._title_to_idx = {
             t.lower(): i for i, t in enumerate(self.df['title'])
         }
@@ -49,10 +76,39 @@ class ContentRecommender:
 
         idx = self._title_to_idx[title.lower()]
         query_vec = self.matrix[idx].reshape(1, -1)
-        scores = cosine_similarity(query_vec, self.matrix).flatten()
-        
-        sim_scores = list(enumerate(scores))
-        sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+        # Candidate retrieval: use ANN for candidate selection if enabled,
+        # otherwise fall back to brute-force over the full matrix.
+        n = int(self.matrix.shape[0]) if getattr(self, 'matrix', None) is not None else 0
+        sim_scores = None
+        if getattr(self, '_ann_enabled', False) and self._ann_index is not None:
+            try:
+                q = query_vec[0] if query_vec.shape[0] == 1 else query_vec
+                k = min(n, max(top_n * 5, top_n)) if n > 0 else top_n
+                labels, dists = self._ann_index.knn_query(q, k=k)
+                # labels is expected to be 2D: take first row
+                candidate_idxs = labels[0].tolist() if hasattr(labels, '__len__') else list(labels)
+                candidate_idxs = [int(i) for i in candidate_idxs if 0 <= int(i) < n]
+                if candidate_idxs:
+                    candidate_matrix = self.matrix[candidate_idxs]
+                    # Recompute exact cosine similarity on ANN candidates to preserve
+                    # the original ranking and scoring semantics (ANN only for candidates).
+                    candidate_scores = cosine_similarity(query_vec, candidate_matrix).flatten()
+                    sim_scores = list(zip(candidate_idxs, candidate_scores))
+                    sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+                else:
+                    # empty candidate set; fall back
+                    scores = cosine_similarity(query_vec, self.matrix).flatten()
+                    sim_scores = list(enumerate(scores))
+                    sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+            except Exception:
+                # Any ANN failure -> fallback to brute-force
+                scores = cosine_similarity(query_vec, self.matrix).flatten()
+                sim_scores = list(enumerate(scores))
+                sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+        else:
+            scores = cosine_similarity(query_vec, self.matrix).flatten()
+            sim_scores = list(enumerate(scores))
+            sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
 
         results = []
         seen = set()
@@ -101,15 +157,41 @@ class ContentRecommender:
         Returns list of matching item titles with scores.
         """
         query_vec = self.model.encode([query])
-        scores = cosine_similarity(query_vec, self.matrix).flatten()
-        
-        # Determine candidate indices matching similarity threshold or top N
-        top_indices = scores.argsort()[::-1]
+
+        # Candidate retrieval: prefer ANN candidates when available, otherwise brute-force
+        n = int(self.matrix.shape[0]) if getattr(self, 'matrix', None) is not None else 0
+        sim_scores = None
+        if getattr(self, '_ann_enabled', False) and self._ann_index is not None:
+            try:
+                q = query_vec[0] if query_vec.shape[0] == 1 else query_vec
+                k = min(n, max(top_n * 5, top_n)) if n > 0 else top_n
+                labels, dists = self._ann_index.knn_query(q, k=k)
+                candidate_idxs = labels[0].tolist() if hasattr(labels, '__len__') else list(labels)
+                candidate_idxs = [int(i) for i in candidate_idxs if 0 <= int(i) < n]
+                if candidate_idxs:
+                    candidate_matrix = self.matrix[candidate_idxs]
+                    # Recompute exact cosine similarity on ANN candidates to preserve
+                    # the original ranking and scoring semantics (ANN only for candidates).
+                    candidate_scores = cosine_similarity(query_vec, candidate_matrix).flatten()
+                    sim_scores = list(zip(candidate_idxs, candidate_scores))
+                    sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+                else:
+                    scores = cosine_similarity(query_vec, self.matrix).flatten()
+                    sim_scores = list(enumerate(scores))
+                    sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+            except Exception:
+                scores = cosine_similarity(query_vec, self.matrix).flatten()
+                sim_scores = list(enumerate(scores))
+                sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
+        else:
+            scores = cosine_similarity(query_vec, self.matrix).flatten()
+            sim_scores = list(enumerate(scores))
+            sim_scores = sorted(sim_scores, key=lambda x: x[1], reverse=True)
 
         results = []
         seen = set()
-        for idx in top_indices:
-            if scores[idx] <= 0:
+        for idx, score in sim_scores:
+            if score <= 0:
                 break
             t = self.df.iloc[idx]['title']
             if t in seen:
@@ -128,7 +210,7 @@ class ContentRecommender:
 
             results.append({
                 'title': t,
-                'score': float(scores[idx]),
+                'score': float(score),
                 'item_id': str(self.df.iloc[idx].get('item_id', idx)),
                 'category': self.df.iloc[idx].get('category', ''),
                 'description': str(self.df.iloc[idx].get('description', ''))[:200],

--- a/tests/test_hnsw_ann_search.py
+++ b/tests/test_hnsw_ann_search.py
@@ -1,0 +1,184 @@
+import importlib
+import sys
+import types
+import builtins
+import numpy as np
+import pandas as pd
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+# Dummy SentenceTransformer to avoid network/model downloads
+class DummySentenceTransformer:
+    def __init__(self, model_name=None):
+        # simple mapping for predictable embeddings
+        self._map = {
+            'a': np.array([1.0, 0.0]),
+            'b': np.array([0.0, 1.0]),
+            'c': np.array([0.9, 0.1]),
+            'd': np.array([0.0, 0.0]),
+        }
+
+    def encode(self, texts, show_progress_bar=False):
+        out = []
+        for t in texts:
+            # texts here are the 'combined' values we set in the test df
+            out.append(self._map.get(t, np.array([0.0, 0.0])))
+        return np.vstack(out)
+
+
+def _make_df():
+    return pd.DataFrame({
+        'title': ['A', 'B', 'C', 'D'],
+        'combined': ['a', 'b', 'c', 'd'],
+        'item_id': [1, 2, 3, 4]
+    })
+
+
+def reload_content_module():
+    if 'src.model.content_model' in sys.modules:
+        return importlib.reload(sys.modules['src.model.content_model'])
+    return importlib.import_module('src.model.content_model')
+
+
+def test_fallback_when_hnswlib_missing(monkeypatch):
+    # Simulate ImportError for hnswlib by monkeypatching __import__
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'hnswlib' or name.startswith('hnswlib.'):
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+    # Reload module so the import behavior is evaluated
+    content_model = reload_content_module()
+    # Replace SentenceTransformer with dummy
+    monkeypatch.setattr(content_model, 'SentenceTransformer', DummySentenceTransformer)
+
+    df = _make_df()
+    recomm = content_model.ContentRecommender(df)
+
+    # ANN should be disabled when hnswlib is not importable
+    assert getattr(recomm, '_ann_enabled', False) is False
+
+    results = recomm.recommend('A', top_n=2)
+    # Top recommendation (excluding the source itself) should be 'C'
+    assert len(results) >= 1
+    assert results[0]['title'] == 'C'
+
+
+def test_ann_index_creation(monkeypatch):
+    # Create fake hnswlib with a simple Index implementation
+    class FakeIndex:
+        def __init__(self, space, dim):
+            self.space = space
+            self.dim = dim
+            self.data = None
+            self.ids = None
+
+        def init_index(self, max_elements, ef_construction, M):
+            pass
+
+        def add_items(self, data, ids):
+            self.data = np.asarray(data)
+            self.ids = np.asarray(ids)
+
+        def set_ef(self, ef):
+            pass
+
+        def knn_query(self, vector, k):
+            v = np.asarray(vector)
+            if v.ndim == 2:
+                v = v[0]
+            sims = cosine_similarity(v.reshape(1, -1), self.data).flatten()
+            idxs = np.argsort(sims)[::-1][:k]
+            labels = self.ids[idxs].reshape(1, -1)
+            dists = (1.0 - sims[idxs]).reshape(1, -1)
+            return labels, dists
+
+    fake_module = types.SimpleNamespace(Index=FakeIndex)
+    monkeypatch.setitem(sys.modules, 'hnswlib', fake_module)
+
+    content_model = reload_content_module()
+    monkeypatch.setattr(content_model, 'SentenceTransformer', DummySentenceTransformer)
+
+    df = _make_df()
+    recomm = content_model.ContentRecommender(df)
+
+    assert getattr(recomm, '_ann_enabled', False) is True
+    assert getattr(recomm, '_ann_index', None) is not None
+
+
+def test_ann_recommendation_parity(monkeypatch):
+    # Fake hnswlib as above
+    class FakeIndex:
+        def __init__(self, space, dim):
+            self.space = space
+            self.dim = dim
+            self.data = None
+            self.ids = None
+
+        def init_index(self, max_elements, ef_construction, M):
+            pass
+
+        def add_items(self, data, ids):
+            self.data = np.asarray(data)
+            self.ids = np.asarray(ids)
+
+        def set_ef(self, ef):
+            pass
+
+        def knn_query(self, vector, k):
+            v = np.asarray(vector)
+            if v.ndim == 2:
+                v = v[0]
+            sims = cosine_similarity(v.reshape(1, -1), self.data).flatten()
+            idxs = np.argsort(sims)[::-1][:k]
+            labels = self.ids[idxs].reshape(1, -1)
+            dists = (1.0 - sims[idxs]).reshape(1, -1)
+            return labels, dists
+
+    fake_module = types.SimpleNamespace(Index=FakeIndex)
+    monkeypatch.setitem(sys.modules, 'hnswlib', fake_module)
+
+    content_model = reload_content_module()
+    monkeypatch.setattr(content_model, 'SentenceTransformer', DummySentenceTransformer)
+    df = _make_df()
+    recomm_ann = content_model.ContentRecommender(df)
+    res_ann = [r['title'] for r in recomm_ann.recommend('A', top_n=3)]
+
+    # Now simulate missing hnswlib
+    monkeypatch.delitem(sys.modules, 'hnswlib', raising=False)
+    content_model_noann = reload_content_module()
+    monkeypatch.setattr(content_model_noann, 'SentenceTransformer', DummySentenceTransformer)
+    recomm_noann = content_model_noann.ContentRecommender(df)
+    res_noann = [r['title'] for r in recomm_noann.recommend('A', top_n=3)]
+
+    # Top-1 should be identical (final ranking uses exact cosine on candidates)
+    assert res_ann[0] == res_noann[0]
+
+
+def test_ann_failure_fallback(monkeypatch):
+    # Fake hnswlib where init_index raises
+    class BrokenIndex:
+        def __init__(self, space, dim):
+            pass
+
+        def init_index(self, max_elements, ef_construction, M):
+            raise RuntimeError('init failed')
+
+    fake_module = types.SimpleNamespace(Index=BrokenIndex)
+    monkeypatch.setitem(sys.modules, 'hnswlib', fake_module)
+
+    content_model = reload_content_module()
+    monkeypatch.setattr(content_model, 'SentenceTransformer', DummySentenceTransformer)
+    df = _make_df()
+    recomm = content_model.ContentRecommender(df)
+
+    # Should have silently disabled ANN
+    assert getattr(recomm, '_ann_enabled', False) is False
+
+    results = recomm.recommend('A', top_n=2)
+    assert len(results) >= 1
+    assert results[0]['title'] == 'C'


### PR DESCRIPTION
## What changed

* Added optional HNSW-based Approximate Nearest Neighbor (ANN) search support to `ContentRecommender`.
* Automatically builds an HNSW index when `hnswlib` is available and embeddings have been generated.
* Updated `recommend()` and `search()` to use HNSW for candidate retrieval when an ANN index is available.
* Preserved existing recommendation quality by re-ranking ANN candidates using exact cosine similarity.
* Added automatic fallback to the existing brute-force cosine similarity implementation when:

  * `hnswlib` is not installed
  * ANN index creation fails
  * ANN queries fail
* Added focused tests covering:

  * ANN index creation
  * ANN recommendation retrieval
  * Fallback behavior when `hnswlib` is unavailable
  * Fallback behavior when ANN initialization fails

## Why

The current implementation performs brute-force cosine similarity across the entire embedding matrix for recommendation and search operations.

As the catalog grows, this becomes increasingly expensive.

HNSW provides efficient approximate nearest neighbor retrieval while maintaining recommendation quality. This implementation uses ANN only for candidate retrieval and then performs exact cosine re-ranking on the candidate set to preserve existing ranking semantics.

Benefits:

* Faster candidate retrieval on larger embedding collections
* Backward-compatible behavior
* No public API changes
* No constructor signature changes
* Graceful fallback when HNSW is unavailable

## How to test

```bash
pytest tests/test_hnsw_ann_search.py -v
```

Expected result:

```text
tests/test_hnsw_ann_search.py::test_fallback_when_hnswlib_missing PASSED
tests/test_hnsw_ann_search.py::test_ann_index_creation PASSED
tests/test_hnsw_ann_search.py::test_ann_recommendation_parity PASSED
tests/test_hnsw_ann_search.py::test_ann_failure_fallback PASSED

4 passed
```

## Screenshots (if UI change)

N/A

## Checklist

* [x] I have read the CONTRIBUTING.md
* [x] My code follows the repository conventions
* [x] I have tested my changes locally
* [x] I have added tests for the new functionality
* [x] No unrelated files were modified
* [x] Existing behavior is preserved when ANN is unavailable

## Related issue

Closes #315 

## Notes

This implementation intentionally keeps the scope minimal:

* Changes are limited to `src/model/content_model.py` and a single focused test file.
* ANN retrieval is optional and automatically disabled when `hnswlib` is unavailable.
* Final ranking continues to use exact cosine similarity to preserve recommendation quality and existing ranking behavior.

## AI assistance disclosure

* [x] I used AI assistance for investigation, review, and drafting support.
* All code changes were reviewed, tested, and understood before submission.
