### PR TITLE
fix: remove duplicate FastAPI app instance in backend/main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -124,7 +124,6 @@ async def csrf_header_dep(
     # This function exists solely to make the header visible in Swagger UI.
 
 app = FastAPI(title="Hybrid Recommender API", version="3.0")
-app = FastAPI(title="Hybrid Recommender API", version="3.0")
 
 @app.on_event("startup")
 def download_nltk_assets():


### PR DESCRIPTION
Removes a duplicate pp = FastAPI(...) on line 127 that overwrites the identical assignment on line 126, leaving only the first definition.