### PR TITLE
fix: remove duplicate import logging and logger init in hybrid_model.py

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 from src.model.causal_config import CausalConfig
 from src.model.causal_model import CausalDebiaser
-import logging
-logger = logging.getLogger(__name__)
 
 def bayesian_rating(rating, review_count, global_avg=3.0, min_votes=10):
     """


### PR DESCRIPTION
Removes a duplicate import logging and logger = logging.getLogger(__name__) on lines 23-24 that shadow the identical imports on lines 13 and 19.