### PR TITLE
fix: correct comment indentation inside run_evaluation()

### DIFF
--- a/src/evaluation/evaluation.py
+++ b/src/evaluation/evaluation.py
@@ -369,7 +369,7 @@ def run_evaluation(
     tfidf_matrix = _load_or_build_tfidf(df)
     svd_matrix   = _load_or_build_svd(df)
 
-# --- build relevance sets from rating data ---
+    # --- build relevance sets from rating data ---
     def _get_relevant(row_idx: int) -> set[str]:
         row = df.iloc[row_idx]
         relevant = set()


### PR DESCRIPTION
Fixes indentation of a comment at line 372 in evaluation.py that was at column 0 inside the un_evaluation() function body, where all other statements use 4-space indentation.