### PR TITLE
fix: use absolute import path for get_supabase_admin in generate_embeddings.py

### DIFF
--- a/backend/scripts/generate_embeddings.py
+++ b/backend/scripts/generate_embeddings.py
@@ -8,7 +8,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from sentence_transformers import SentenceTransformer
-from db import get_supabase_admin
+from src.data.db import get_supabase_admin
 from dotenv import load_dotenv
 
 load_dotenv()


### PR DESCRIPTION
Changes rom db import get_supabase_admin to rom src.data.db import get_supabase_admin to use a proper absolute import path consistent with the rest of the project, avoiding reliance on fragile sys.path manipulation.