### PR TITLE
fix: use absolute import paths in dataset_manager.py

### DIFF
--- a/src/data/dataset_manager.py
+++ b/src/data/dataset_manager.py
@@ -2,8 +2,8 @@ import pandas as pd
 import os
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
-from data_adapter import adapt_data
-from data_preprocessing import preprocess
+from src.data.data_adapter import adapt_data
+from src.data.data_preprocessing import preprocess
 
 
 class DatasetManager:


### PR DESCRIPTION
Changes rom data_adapter import adapt_data and rom data_preprocessing import preprocess to use proper absolute import paths (rom src.data.data_adapter / rom src.data.data_preprocessing), avoiding reliance on fragile sys.path manipulation and making the module importable from any working directory.