### PR TITLE
fix: add missing trailing newline to backend/csrf.py

### DIFF
--- a/backend/csrf.py
+++ b/backend/csrf.py
@@ -247,3 +247,4 @@ class CSRFMiddleware:
 
         # 7. Both tokens present and identical — pass to the next handler.
         await self._app(scope, receive, send)
+


### PR DESCRIPTION
Adds the missing trailing newline at end of backend/csrf.py to conform to POSIX standards.