### PR TITLE
fix: remove leading blank line in feature_store.py

### DIFF
--- a/src/model/feature_store.py
+++ b/src/model/feature_store.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pickle
 import os


### PR DESCRIPTION
Removes the extraneous blank line at the start of feature_store.py that violates PEP 8 (no leading blank lines before imports or module docstring).