### PR TITLE
fix: add missing trailing newline to causal_evaluation.py

### DIFF
--- a/src/evaluation/causal_evaluation.py
+++ b/src/evaluation/causal_evaluation.py
@@ -239,3 +239,4 @@ def score_key_distribution(
         "max": round(float(arr.max()), 4),
         "n_scores": len(all_scores),
     }
+


### PR DESCRIPTION
Adds missing trailing newline at end of file.