### PR TITLE
fix: add missing trailing newline to causal_model.py

### DIFF
--- a/src/model/causal_model.py
+++ b/src/model/causal_model.py
@@ -272,3 +272,4 @@ class CausalDebiaser:
             "blend_lambda": self.blend_lambda,
             "clip_max": self.clip_max,
         }
+


### PR DESCRIPTION
Adds missing trailing newline at end of file.