### PR TITLE
fix: add trailing newline to tests\test_admin_dashboard_auth.py

### DIFF
--- a/tests/test_admin_dashboard_auth.py
+++ b/tests/test_admin_dashboard_auth.py
@@ -42,3 +42,4 @@ def test_admin_access_rejects_missing_or_invalid_token(monkeypatch):
 
     assert exc.value.status_code == 401
     assert exc.value.detail == "Admin token required."
+


### PR DESCRIPTION
Fixes missing trailing newline.