### PR TITLE
fix: add trailing newline to tests\test_api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,3 +38,4 @@ def test_version_endpoint():
         "service": "Hybrid Recommender API",
         "status": "running",
     }
+


### PR DESCRIPTION
Fixes missing trailing newline.