### PR TITLE
fix: add trailing newline to tests\test_api_similar.py

### DIFF
--- a/tests/test_api_similar.py
+++ b/tests/test_api_similar.py
@@ -87,3 +87,4 @@ def test_similar_items_endpoint_requires_built_models(api_client):
 
     assert response.status_code == 400
     assert "Models not built" in response.json()["detail"]
+


### PR DESCRIPTION
Fixes missing trailing newline.