### PR TITLE
fix: add trailing newline to tests\test_autocomplete.py

### DIFF
--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -78,3 +78,4 @@ def test_autocomplete_db_failure_returns_500(monkeypatch):
 
     response = client.get("/api/autocomplete?q=naruto")
     assert response.status_code == 500
+


### PR DESCRIPTION
Fixes missing trailing newline.