### PR TITLE
fix: add trailing newline to tests\test_causal_config.py

### DIFF
--- a/tests/test_causal_config.py
+++ b/tests/test_causal_config.py
@@ -76,3 +76,4 @@ class TestCausalConfigSpec:
     def test_from_dict_validation_error(self):
         with pytest.raises(ValueError):
             CausalConfig.from_dict({'blend_lambda': -5.0})
+


### PR DESCRIPTION
Fixes missing trailing newline.