### PR TITLE
fix: add trailing newline to tests\test_causal_integration.py

### DIFF
--- a/tests/test_causal_integration.py
+++ b/tests/test_causal_integration.py
@@ -352,3 +352,4 @@ class TestCausalEvaluation:
             causal_model, baseline_model, item_df, [], top_n=3
         )
         assert result["n_queries"] == 0
+


### PR DESCRIPTION
Fixes missing trailing newline.