### PR TITLE
fix: add trailing newline to tests\test_causal_model.py

### DIFF
--- a/tests/test_causal_model.py
+++ b/tests/test_causal_model.py
@@ -478,3 +478,4 @@ class TestHybridCausalIntegration:
         w = d.get_ips_weight('Rare E')
         assert w <= 100.0
 
+


### PR DESCRIPTION
Fixes missing trailing newline.