### PR TITLE
fix: add trailing newline to tests\test_cold_start_and_cache.py

### DIFF
--- a/tests/test_cold_start_and_cache.py
+++ b/tests/test_cold_start_and_cache.py
@@ -44,3 +44,4 @@ def test_cache_metrics_hit_miss():
     _ = backend._get_cached_response('k1')
     after = client.get('/api/cache_metrics').json()
     assert after['hits'] >= 1
+


### PR DESCRIPTION
Fixes missing trailing newline.