### PR TITLE
fix: add trailing newline to tests\test_csrf.py

### DIFF
--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -311,3 +311,4 @@ def test_set_csrf_cookie_writes_correct_attributes():
 
     # Cache-Control: no-store must be set on the response
     assert resp.headers.get("cache-control") == "no-store"
+


### PR DESCRIPTION
Fixes missing trailing newline.