### PR TITLE
fix: add trailing newline to tests\test_evaluation_metrics.py

### DIFF
--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -126,3 +126,4 @@ class TestNDCGAtK:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+


### PR DESCRIPTION
Fixes missing trailing newline.