### PR TITLE
fix(model): add missing kg_model and delta params to HybridRecommende…

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -37,7 +37,8 @@ class HybridRecommender:
                  alpha=0.4, beta=0.35, gamma=0.25,
                  normalization='minmax', weight_matrix=None,
                  use_causal_debiasing=False, causal_lambda=0.5, causal_clip=5.0,
-                 causal_config=None, model_kwargs=None):
+                 causal_config=None, model_kwargs=None,
+                 kg_model=None, delta=0.0):
         """
         content_model:        ContentRecommender instance
         collab_model:         CollaborativeRecommender instance (optional)


### PR DESCRIPTION

## What changed
kg_model and delta were referenced in the constructor body but absent from the parameter list. Added kg_model=None, delta=0.0 to the signature. File: src/model/hybrid_model.py — 2 lines changed.

## Why
<!-- Explain the problem this solves or the feature this adds -->

## How to test
<!-- Step-by-step instructions to test your changes locally -->
```bash
# Example:
pip install -r requirements.txt
python test_pipeline.py
```

## Screenshots (if UI change)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I can explain every line of code I've written
- [ ] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #1230

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
