### PR TITLE
feat: add recommendation history tracking

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 from src.model.causal_config import CausalConfig
 from src.model.causal_model import CausalDebiaser
+from src.model.recommendation_history import history_tracker
 
 def bayesian_rating(rating, review_count, global_avg=3.0, min_votes=10):
     """
@@ -521,6 +522,12 @@ class HybridRecommender:
             return self._cold_start_fallback(title=None, top_n=top_n)
 
         collab_recs = self.collab_model.predict_for_user(user_id, top_n=top_n * 3)
+        recent_titles = history_tracker.get_recent_titles(user_id)
+
+        collab_recs = [ 
+            rec for rec in collab_recs
+            if rec["title"] not in recent_titles
+        ]
         
         results = []
         for r in collab_recs[:top_n]:
@@ -562,7 +569,12 @@ class HybridRecommender:
             results = self._debiaser.debias_batch(results, score_key=score_key)
             results.sort(key=lambda x: x[score_key], reverse=True)
 
-        return results
+            for item in results:
+                history_tracker.add_recommendation(
+                    user_id,
+                    item["title"]
+                    )
+                return results
 
     def _build_explanation(
         self,

--- a/src/model/recommendation_history.py
+++ b/src/model/recommendation_history.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+from datetime import datetime
+
+
+class RecommendationHistory:
+    def __init__(self):
+        self.history = defaultdict(list)
+
+    def add_recommendation(self, user_id, item_title):
+        self.history[user_id].append({
+            "title": item_title,
+            "timestamp": datetime.now()
+        })
+
+        # Keep only last 50 records
+        self.history[user_id] = self.history[user_id][-50:]
+
+    def get_history(self, user_id):
+        return self.history.get(user_id, [])
+
+    def get_recent_titles(self, user_id):
+        return {
+            item["title"]
+            for item in self.history.get(user_id, [])
+        }
+
+
+history_tracker = RecommendationHistory()


### PR DESCRIPTION
## What changed

Implemented recommendation history tracking for users.

### Features Added
- Created a `RecommendationHistory` module to store recommendation history.
- Added support for tracking recommendations served to each user.
- Limited history storage to the most recent 50 recommendations per user.
- Added methods to retrieve user history and recently recommended titles.
- Integrated history tracking into the hybrid recommendation workflow.
- Filtered out recently recommended items to reduce repetitive recommendations.

## Why

Previously, users could receive the same recommendations repeatedly across sessions. This feature improves recommendation diversity and user experience by tracking recommendation history and avoiding recently served items.

## How to test

1. Build and run the recommender system.
2. Generate recommendations for a user.
3. Generate recommendations again for the same user.
4. Verify that recently recommended items are excluded from the new recommendations.
5. Confirm that recommendation history is being stored and maintained correctly.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Related Issue

Closes #919

## AI Assistance Disclosure

- [x] Used AI assistance for implementation guidance, debugging, and code review.