### PR TITLE
fix: anchor KG embeddings script to repo root

### DIFF
--- a/scripts/generate_kg_embeddings.py
+++ b/scripts/generate_kg_embeddings.py
@@ -1,10 +1,16 @@
 import pandas as pd
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.model.knowledge_graph_model import KnowledgeGraphRecommender
 
 
 if __name__ == '__main__':
-    df = pd.read_csv('datasets/books.csv')
+    df = pd.read_csv(PROJECT_ROOT / 'datasets' / 'booksdata.csv')
 
     model = KnowledgeGraphRecommender(df)
 


### PR DESCRIPTION
Fixes the launcher so `scripts/generate_kg_embeddings.py` works from the `scripts/` directory, and switches it to the dataset schema expected by `KnowledgeGraphRecommender`.

Verification: `cd scripts && python3 generate_kg_embeddings.py`