### PR TITLE
fix: resolve merge conflict in src api main

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -117,13 +117,11 @@ def get_recommendations(req: RecommendationRequest):
             _item_df,
             causal_config=causal_cfg,
         )
-
-<<<<<<< HEAD
         recs = model.recommend(title=req.query, user_id=req.user_id, top_n=req.top_n)
         return {
             "recommendations": recs,
             "causal_debiasing_applied": req.use_causal,
-            "fallback": False
+            "fallback": False,
         }
 
     # ===================================================================
@@ -167,10 +165,3 @@ def get_recommendations(req: RecommendationRequest):
         except Exception as fallback_exc:
             logger.critical(f"Critical System Outage: Fallback engine failed: {str(fallback_exc)}")
             raise HTTPException(status_code=500, detail="Recommendation engine completely offline.")
-=======
-    recs = model.recommend(title=req.query, user_id=req.user_id, top_n=req.top_n)
-    return {
-        "recommendations": recs,
-        "causal_debiasing_applied": req.use_causal,
-    }
->>>>>>> fea1db0 (fix: safeguard github webhook against null payloads and fix api indentation)


### PR DESCRIPTION
Resolves the leftover merge conflict markers in `src/api/main.py`, restoring a valid importable module and keeping the fallback recommendation path intact.

Verification: `python3 - <<'PY' ... compile(...) ... PY` on the file contents.