### PR TITLE
fix(model): remove stray bare tokens t and l from HybridRecommender.r…

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -404,9 +404,7 @@ class HybridRecommender:
         sentiment_scores = self._normalize_scores(sentiment_raws)
 
         kg_scores = []
-        t
         if self.kg_model:
-            l
             kg_recs = self.kg_model.recommend(title, top_n=top_n * 3)
            
             kg_map = {


### PR DESCRIPTION

## What changed
Removed the dangling t (line 407) and l (line 409) tokens that were left in the kg_model branch of recommend(). These caused NameError at runtime whenever kg_model was set. File: src/model/hybrid_model.py — 2 lines deleted.

## Why
<!-- Explain the problem this solves or the feature this adds -->

## How to test
<!-- Step-by-step instructions to test your changes locally -->
```bash
# Example:
pip install -r requirements.txt
python test_pipeline.py
```

## Screenshots (if UI change)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] My code follows PEP8 style (`flake8 .`)
- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I can explain every line of code I've written
- [ ] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #1250 

## AI assistance disclosure
<!-- If you used AI tools (Copilot, ChatGPT, etc.), describe how below. Concealment = disqualification. -->
- [ ] I did not use AI assistance for this PR
- [ ] I used AI assistance for: <!-- describe what -->
