### PR TITLE
"fix: clear top products list before rendering"

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -107,6 +107,8 @@ async function loadDashboard() {
 
   const list = document.getElementById('top-products');
 
+  list.innerHTML = '';
+
   data.top_5_recommended_products.forEach(product => {
     const li = document.createElement('li');
     li.textContent = product;


### PR DESCRIPTION
What changed

- Added "list.innerHTML = ''" before rendering the top recommended products list.
- Ensured that existing list items are cleared before appending new products.

Why

The dashboard appends products to the "top-products" list every time "loadDashboard()" is executed. Since the existing list is not cleared beforehand, repeated executions can result in duplicate product entries being displayed.

This change ensures that the list always reflects the latest API response without duplicating items.

How to test

1. Run the application.
2. Open the dashboard page.
3. Trigger "loadDashboard()" multiple times (for example through page refreshes, re-renders, or manual invocation in the browser console).
4. Verify that the "Top 5 Recommended Products" list contains only the latest products and does not accumulate duplicate entries.

Screenshots (if UI change)

Not required. This change affects rendering behavior and does not introduce visual UI modifications.

Checklist

- [x] I have read the CONTRIBUTING.md
- [x] My code follows PEP8 style ("flake8 .")
- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

Related issue

Closes #1113 