### PR TITLE
fix: stop recommend() overwriting query title parameter inside iteration loops

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -367,25 +367,21 @@ class HybridRecommender:
         for r in content_recs:
             if not isinstance(r, dict):
                 continue
+            item_title = r.get("title")
+            if item_title:
+                all_titles.add(item_title)
 
-            title = r.get("title")
-            if title:
-                all_titles.add(title)
-
-        # 2. Collaborative scores
         collab_map = {}
         if self.collab_model:
             collab_recs = self.collab_model.recommend(title, top_n=top_n * 3, target_catalog=target_catalog)
             for r in collab_recs:
                 if not isinstance(r, dict):
                     continue
-
-                title = r.get("title")
-                if not title:
+                item_title = r.get("title")
+                if not item_title:
                     continue
-
-                collab_map[title] = r.get("collab_score", 0.0)
-                all_titles.add(title)
+                collab_map[item_title] = r.get("collab_score", 0.0)
+                all_titles.add(item_title)
 
         # 3. Build unified candidates
         candidates = {}


### PR DESCRIPTION
Fixes a silent correctness bug where the `title` parameter of `recommend()`
was overwritten inside `for` loops iterating over content and collab results,
causing collaborative scores, cold-start fallback, and explanations to all
use the wrong item title.


issue closes #1285 