### PR TITLE
fix: move return and history tracking outside for loop

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -583,12 +583,10 @@ class HybridRecommender:
             results = self._debiaser.debias_batch(results, score_key=score_key)
             results.sort(key=lambda x: x[score_key], reverse=True)
 
-            for item in results:
-                history_tracker.add_recommendation(
-                    user_id,
-                    item["title"]
-                    )
-                return results
+        for item in results:
+            history_tracker.add_recommendation(user_id, item["title"])
+
+        return results
 
     def _build_explanation(
         self,


### PR DESCRIPTION
Fixes two bugs in `recommend_for_user()` that caused it to return `None`
on every standard request and only record one history entry.


Closeses #1289
