### PR TITLE
fix: move global_avg before conditional and remove duplicate _bayesian in get_popular_fallback_items

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -790,12 +790,11 @@ class HybridRecommender:
             return []
 
         df = df.copy()
+        global_avg = 3.0  # always defined before use
         if exclude_title is not None and 'title' in df.columns:
             df = df[df['title'] != exclude_title]
-            global_avg = 3.0
         # Sort by Bayesian rating
         if 'rating' in df.columns and 'review_count' in df.columns:
-            df['_bayesian'] = df.apply(lambda r: bayesian_rating(r['rating'], r.get('review_count', 0), global_avg), axis=1)
             df['_bayesian'] = df.apply(
                 lambda r: bayesian_rating(r['rating'], r.get('review_count', 0), global_avg), axis=1
             )


### PR DESCRIPTION
## Summary
Fixes a `NameError` crash and removes redundant computation in
`get_popular_fallback_items()`.

## Changes
1. Moved `global_avg = 3.0` above the `if exclude_title` block so it is
   always defined before use in the `bayesian_rating` lambda.
2. Removed the duplicate `_bayesian` column assignment — the second was
   an exact copy of the first and was immediately overwriting it.


Closes #1294 