### PR TITLE
fix(recommender): handle cold-start users without crashing (#1318)

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -37,7 +37,8 @@ class HybridRecommender:
                  alpha=0.4, beta=0.35, gamma=0.25,
                  normalization='minmax', weight_matrix=None,
                  use_causal_debiasing=False, causal_lambda=0.5, causal_clip=5.0,
-                 causal_config=None, model_kwargs=None):
+                 causal_config=None, model_kwargs=None,
+                 kg_model=None, delta=0.0):
         """
         content_model:        ContentRecommender instance
         collab_model:         CollaborativeRecommender instance (optional)
@@ -351,9 +352,9 @@ class HybridRecommender:
             if not isinstance(r, dict):
                 continue
 
-            title = r.get("title")
-            if title:
-                all_titles.add(title)
+            _r_title = r.get("title")
+            if _r_title:
+                all_titles.add(_r_title)
 
         # 2. Collaborative scores
         collab_map = {}
@@ -363,12 +364,12 @@ class HybridRecommender:
                 if not isinstance(r, dict):
                     continue
 
-                title = r.get("title")
-                if not title:
+                _r_title = r.get("title")
+                if not _r_title:
                     continue
 
-                collab_map[title] = r.get("collab_score", 0.0)
-                all_titles.add(title)
+                collab_map[_r_title] = r.get("collab_score", 0.0)
+                all_titles.add(_r_title)
 
         # 3. Build unified candidates
         candidates = {}
@@ -403,10 +404,15 @@ class HybridRecommender:
         collab_scores = self._normalize_scores(collab_raws)
         sentiment_scores = self._normalize_scores(sentiment_raws)
 
+        # 5. Get active weights for this request
+        a, b, g = self._get_active_weights(
+            self.alpha, self.beta, self.gamma,
+            user_id=user_id,
+            candidate_titles=list(candidates.keys()),
+        )
+
         kg_scores = []
-        t
         if self.kg_model:
-            l
             kg_recs = self.kg_model.recommend(title, top_n=top_n * 3)
            
             kg_map = {
@@ -511,14 +517,26 @@ class HybridRecommender:
 
         return results[:top_n]
     
+    def get_fallback_recommendations(self, top_n=10, target_catalog=None):
+        """
+        Return popularity-based fallback recommendations for cold-start or unknown users.
+        """
+        return self._cold_start_fallback(title=None, top_n=top_n, target_catalog=target_catalog)
+
     def recommend_for_user(self, user_id, top_n=10, explain=False):
         """
         Get recommendations for a specific user.
         If the user is new (or no collab model exists), fallback to popular items.
         """
+        if user_id is None:
+            logger.warning("recommend_for_user called with user_id=None. Using cold-start fallback recommendations.")
+            return self.get_fallback_recommendations(top_n=top_n)
+
         if self.collab_model is None or user_id not in self.collab_model._user_to_idx:
-            # Cold start fallback for new user
-            return self._cold_start_fallback(title=None, top_n=top_n)
+            logger.warning(
+                "User %r not found. Using cold-start fallback recommendations.", user_id
+            )
+            return self.get_fallback_recommendations(top_n=top_n)
 
         collab_recs = self.collab_model.predict_for_user(user_id, top_n=top_n * 3)
         
@@ -743,9 +761,9 @@ class HybridRecommender:
             return []
 
         df = df.copy()
+        global_avg = 3.0
         if exclude_title is not None and 'title' in df.columns:
             df = df[df['title'] != exclude_title]
-            global_avg = 3.0
         # Sort by Bayesian rating
         if 'rating' in df.columns and 'review_count' in df.columns:
             df['_bayesian'] = df.apply(lambda r: bayesian_rating(r['rating'], r.get('review_count', 0), global_avg), axis=1)

--- a/tests/test_cold_start_user_1318.py
+++ b/tests/test_cold_start_user_1318.py
@@ -1,0 +1,150 @@
+"""
+Regression tests for Issue #1318: cold-start / unknown user handling.
+
+Ensures that recommendation requests for unknown or invalid user IDs never
+crash the application and always return a safe fallback list.
+"""
+import pytest
+import pandas as pd
+
+from src.model.hybrid_model import HybridRecommender
+from src.model.collaborative_model import CollaborativeRecommender
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def item_df():
+    return pd.DataFrame({
+        "title": ["Product A", "Product B", "Product C", "Product D"],
+        "description": ["desc A", "desc B", "desc C", "desc D"],
+        "category": ["Electronics", "Electronics", "Home", "Home"],
+        "rating": [4.5, 3.8, 4.9, 3.2],
+        "review_count": [120, 45, 200, 10],
+        "avg_sentiment": [0.6, 0.2, 0.8, 0.1],
+        "combined": [
+            "Product A desc A Electronics",
+            "Product B desc B Electronics",
+            "Product C desc C Home",
+            "Product D desc D Home",
+        ],
+    })
+
+
+@pytest.fixture
+def interaction_df():
+    return pd.DataFrame({
+        "user_id": ["u1", "u1", "u2", "u2", "u3"],
+        "title": ["Product A", "Product B", "Product B", "Product C", "Product A"],
+        "rating": [5.0, 3.0, 4.0, 5.0, 4.0],
+    })
+
+
+class _MockContentModel:
+    """Minimal content model stub that avoids loading SentenceTransformer."""
+
+    def __init__(self, df):
+        self.df = df
+
+    def recommend(self, title, top_n=10, target_catalog=None):
+        rows = self.df[self.df["title"] != title].head(top_n)
+        return [{"title": row["title"], "content_score": 0.5} for _, row in rows.iterrows()]
+
+    def search(self, query, top_n=10):
+        return []
+
+
+@pytest.fixture
+def hybrid_model(item_df, interaction_df):
+    content = _MockContentModel(item_df)
+    collab = CollaborativeRecommender(interaction_df)
+    return HybridRecommender(content, collab_model=collab, item_df=item_df)
+
+
+@pytest.fixture
+def hybrid_model_no_collab(item_df):
+    content = _MockContentModel(item_df)
+    return HybridRecommender(content, collab_model=None, item_df=item_df)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Existing user receives normal personalized recommendations
+# ---------------------------------------------------------------------------
+
+def test_existing_user_gets_recommendations(hybrid_model):
+    recs = hybrid_model.recommend_for_user("u1", top_n=3)
+    assert isinstance(recs, list)
+    assert len(recs) > 0
+    required_keys = {"title", "hybrid_score", "collab_score", "content_score", "sentiment_score"}
+    for r in recs:
+        assert required_keys.issubset(r.keys()), f"Missing keys in {r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Non-existent user ID returns fallback recommendations, not an error
+# ---------------------------------------------------------------------------
+
+def test_nonexistent_user_returns_fallback(hybrid_model):
+    recs = hybrid_model.recommend_for_user("user_999999999", top_n=3)
+    assert isinstance(recs, list)
+    assert len(recs) > 0, "Fallback must return at least one item when catalog data exists"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Unknown user does not raise KeyError
+# ---------------------------------------------------------------------------
+
+def test_unknown_user_no_keyerror(hybrid_model):
+    try:
+        hybrid_model.recommend_for_user("completely_unknown_xyz", top_n=3)
+    except KeyError as exc:
+        pytest.fail(f"KeyError raised for unknown user: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Unknown user does not crash application flow
+# ---------------------------------------------------------------------------
+
+def test_unknown_user_no_crash(hybrid_model):
+    try:
+        recs = hybrid_model.recommend_for_user("no_such_user_abc", top_n=3)
+        assert isinstance(recs, list)
+    except Exception as exc:
+        pytest.fail(f"Unexpected exception for unknown user: {type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Fallback list is non-empty when catalog data exists
+# ---------------------------------------------------------------------------
+
+def test_fallback_nonempty_with_catalog(hybrid_model):
+    recs = hybrid_model.get_fallback_recommendations(top_n=4)
+    assert len(recs) > 0, "get_fallback_recommendations must return items when item_df is populated"
+    for r in recs:
+        assert "title" in r
+        assert "hybrid_score" in r
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Invalid user IDs are handled gracefully (None, negative int, empty string)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_user_id", [None, -1, "", "   "])
+def test_invalid_user_ids_handled_gracefully(hybrid_model, bad_user_id):
+    try:
+        recs = hybrid_model.recommend_for_user(bad_user_id, top_n=3)
+        assert isinstance(recs, list), f"Expected list for user_id={bad_user_id!r}"
+    except (KeyError, IndexError) as exc:
+        pytest.fail(f"Crash ({type(exc).__name__}) for user_id={bad_user_id!r}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Extra: no collab model still provides fallback for any user
+# ---------------------------------------------------------------------------
+
+def test_no_collab_model_fallback_for_any_user(hybrid_model_no_collab):
+    recs = hybrid_model_no_collab.recommend_for_user("u1", top_n=3)
+    assert isinstance(recs, list)
+    assert len(recs) > 0

--- a/tests/test_hybrid_popularity_fallback.py
+++ b/tests/test_hybrid_popularity_fallback.py
@@ -7,7 +7,7 @@ class EmptyContentModel:
     def __init__(self, df):
         self.df = df
 
-    def recommend(self, title, top_n=10):
+    def recommend(self, title, top_n=10, target_catalog=None):
         return []
 
 


### PR DESCRIPTION
Closes #1318

## Summary

- Added cold-start user handling: `recommend_for_user` now guards against unknown and `None` user IDs before any matrix lookup, emitting a `WARNING`-level log entry and returning popularity-based fallback results instead of crashing
- Added `get_fallback_recommendations()` as a public helper that surfaces the existing popularity-ranked fallback to callers outside the class
- Prevented `NameError` crashes: `kg_model` and `delta` were referenced in `__init__` without being declared as parameters; both are now proper optional keyword arguments with safe defaults
- Prevented `NameError` in `get_popular_fallback_items`: `global_avg` was only assigned inside the `exclude_title` branch, causing a crash for every cold-start user path where `title=None`; moved the assignment before the conditional
- Fixed `title` variable collision in `recommend()`: the query title was being overwritten by loop variables, causing collaborative scores to be fetched for the wrong item; renamed loop temporaries to `_r_title`
- Removed stray bare token expressions (`t`, `l`) and added the missing active-weights assignment (`a, b, g`) that was causing `NameError` in the hybrid-score loop
- Fixed `EmptyContentModel` stub in `test_hybrid_popularity_fallback.py` to accept the `target_catalog` keyword that `recommend()` now correctly forwards
- Added regression tests covering all six scenarios from the issue: known user, unknown user, `KeyError` guard, crash guard, non-empty fallback, and invalid user IDs (`None`, negative, empty string)