### PR TITLE
fix(auth): remove duplicate _admin_access_dep definitions and dead inner function

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -518,20 +518,15 @@ def _require_admin_access(request: Request) -> None:
     )
     if not provided_token or not secrets.compare_digest(provided_token, expected_token):
         raise HTTPException(status_code=401, detail="Admin token required.")
-    def _admin_access_dep(request: Request):
-        _require_admin_access(request)
-
-_admin_access_dep = _require_admin_access
-
 
 
 def _admin_access_dep(request: Request) -> None:
-    """FastAPI dependency wrapper around _require_admin_access."""
-    _require_admin_access(request)
+    """FastAPI dependency that enforces admin token authentication.
 
-
-def _admin_access_dep(request: Request) -> None:
-    """FastAPI dependency wrapper around _require_admin_access."""
+    Used with ``Depends(_admin_access_dep)`` on admin-only endpoints.
+    Raises HTTP 401 if the token is missing or invalid, HTTP 500 if
+    the server-side token has not been configured.
+    """
     _require_admin_access(request)
 
 


### PR DESCRIPTION
## What changed

Removed three redundant definitions of `_admin_access_dep` in `backend/main.py` and consolidated into a single, canonical module-level function with a proper docstring.

**Before — 4 overlapping definitions:**
```python
def _require_admin_access(request: Request) -> None:
    ...
    if not provided_token or ...:
        raise HTTPException(status_code=401, ...)
    def _admin_access_dep(request: Request):      # ← inner fn, dead code
        _require_admin_access(request)

_admin_access_dep = _require_admin_access         # ← alias at module level

def _admin_access_dep(request: Request) -> None:  # ← duplicate 1
    """FastAPI dependency wrapper around _require_admin_access."""
    _require_admin_access(request)

def _admin_access_dep(request: Request) -> None:  # ← duplicate 2 (identical)
    """FastAPI dependency wrapper around _require_admin_access."""
    _require_admin_access(request)
```

**After — single canonical definition:**
```python
def _require_admin_access(request: Request) -> None:
    ...
    if not provided_token or ...:
        raise HTTPException(status_code=401, ...)


def _admin_access_dep(request: Request) -> None:
    """FastAPI dependency that enforces admin token authentication.

    Used with ``Depends(_admin_access_dep)`` on admin-only endpoints.
    Raises HTTP 401 if the token is missing or invalid, HTTP 500 if
    the server-side token has not been configured.
    """
    _require_admin_access(request)
```

## Why

- The inner `_admin_access_dep` at line 521 was defined inside `_require_admin_access`. It was local scope, never called or returned — pure dead code that ran on every admin request without effect.
- The module-level alias (`_admin_access_dep = _require_admin_access`) and two identical `def` blocks are all redundant — Python uses the last definition, so only one survives anyway.
- Having four definitions makes it impossible to tell which is authoritative and creates maintenance confusion.
- The surviving definition now has a proper docstring per the project's code standards.

## How to test

```bash
# Start the backend
uvicorn backend.main:app --reload

# Confirm admin endpoints respond with 401 when no token provided
curl -X POST http://localhost:8000/api/build
# Expected: {"detail": "Admin token required."}

# Confirm they work with a valid token
curl -X POST http://localhost:8000/api/build \
  -H "X-Admin-Token: <your_admin_token>"
# Expected: 200 or appropriate response
```

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #1278

## AI assistance disclosure
- [x] I did not use AI assistance for this PR