### PR TITLE
docs: fix Supabase placeholders in setup guide

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -21,7 +21,7 @@ cp .env.example .env
 
 Fill in:
 ```
-SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_KEY=your-service-role-key
 ```


### PR DESCRIPTION
Clarifies placeholder credential names in the setup docs.