### PR TITLE
fix: correct typo in hybrid explanation scores

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -647,7 +647,7 @@ class HybridRecommender:
                 'content': round(content_score, 4),
                 'collaborative': round(collab_score, 4),
                 'sentiment': round(sentiment_score, 4),
-                'raw_content': roaund(raw_item['raw_content'], 4),
+                'raw_content': round(raw_item['raw_content'], 4),
                 'raw_collaborative': round(raw_item['raw_collab'], 4),
                 'raw_sentiment': round(raw_item['raw_sentiment'], 4),
             },

--- a/tests/test_hybrid_explanation_typo.py
+++ b/tests/test_hybrid_explanation_typo.py
@@ -1,0 +1,23 @@
+from src.model.hybrid_model import HybridRecommender
+
+
+class _ContentStub:
+    def explain_similarity(self, source_title, candidate_title):
+        return []
+
+
+def test_build_explanation_uses_round():
+    model = HybridRecommender(_ContentStub(), item_df=None)
+    explanation = model._build_explanation(
+        source_title='Product A',
+        candidate_title='Product B',
+        content_score=0.7,
+        collab_score=0.2,
+        sentiment_score=0.1,
+        popularity=0.4,
+        alpha=0.5,
+        beta=0.3,
+        gamma=0.2,
+        raw_item={'raw_content': 0.6, 'raw_collab': 0.1, 'raw_sentiment': 0.0},
+    )
+    assert explanation['component_scores']['raw_content'] == 0.6


### PR DESCRIPTION
Fixes the roaund() typo in HybridRecommender._build_explanation and adds a regression test.