### PR TITLE
fix(frontend): use template literal for toast transition in toast()

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -239,7 +239,7 @@ function toast(message, type = 'info') {
     setTimeout(() => {
         el.style.opacity = '0';
         el.style.transform = 'translateX(100%)';
-        el.style.transition = '${CONFIG.TOAST_EXIT_MS}ms ease';
+        el.style.transition = `${CONFIG.TOAST_EXIT_MS}ms ease`;
         setTimeout(() => el.remove(), CONFIG.TOAST_EXIT_MS);
     }, CONFIG.TOAST_DURATION_MS);
 }


### PR DESCRIPTION
Changed single quotes to backticks on line 242 so CONFIG.TOAST_EXIT_MS is correctly interpolated to e.g. 300ms ease. File: frontend/app.js — 1 character changed.

closes #1484 