### PR TITLE
fix(model): guard undefined history_tracker in recommend_for_user to …

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -528,7 +528,8 @@ class HybridRecommender:
             )
 
         collab_recs = self.collab_model.predict_for_user(mapped_user_id, top_n=top_n * 3)
-        recent_titles = history_tracker.get_recent_titles(mapped_user_id)
+        _tracker = getattr(self, 'history_tracker', None)
+        recent_titles = _tracker.get_recent_titles(mapped_user_id) if _tracker is not None else set()
 
         collab_recs = [ 
             rec for rec in collab_recs


### PR DESCRIPTION
Replaced the bare history_tracker.get_recent_titles() call with a guarded getattr(self, 'history_tracker', None) check — returns empty set when tracker is unavailable, preserving the filter logic safely. File: src/model/hybrid_model.py — 2 lines changed.

closes #1486 