### PR TITLE
fix(model): add missing validate_recommendations import to hybrid_mod…

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from src.model.causal_config import CausalConfig
 from src.model.causal_model import CausalDebiaser
+from src.model.validation import validate_recommendations
 
 
 def bayesian_rating(rating, review_count, global_avg=3.0, min_votes=10):


### PR DESCRIPTION
Added from src.model.validation import validate_recommendations to hybrid_model.py. This import exists in collaborative_model.py but was missing here. File: src/model/hybrid_model.py — 1 line added.

closes #1492 