### PR TITLE
fix(backend): remove duplicate else clause in rate limiter causing SyntaxError

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -252,7 +252,6 @@ def _apply_rate_limit(*args, **kwargs):
             _rate_limit_buckets[ip_address] = bucket
         else:
             _rate_limit_buckets.move_to_end(ip_address)
-        else:
             elapsed = current_time - bucket["last_updated"]
             bucket["tokens"] = min(10.0, bucket["tokens"] + elapsed * 1.0)
             bucket["last_updated"] = current_time


### PR DESCRIPTION

Merged the two else: clauses in _apply_rate_limit() into one — the token refresh logic now correctly runs inside the single else branch after move_to_end. File: backend/main.py — 1 line deleted.

closes #1494 