### PR TITLE
fix: replace hardcoded Windows path in scan.py with dynamic repo root

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import re
 
 PATTERNS = {
@@ -33,4 +34,5 @@ def scan_dir(d):
                 pass
 
 if __name__ == '__main__':
-    scan_dir('C:\\Users\\user\\.gemini\\antigravity\\scratch\\hybrid-recommender')
+    repo_root = pathlib.Path(__file__).parent
+    scan_dir(str(repo_root))


### PR DESCRIPTION
## What does this PR do?

Replaces the hardcoded absolute Windows path in `scan.py`'s `__main__` block with `pathlib.Path(__file__).parent`, making the security scanner work on any machine and OS.

**Before:**
```python
if __name__ == '__main__':
    scan_dir('C:\\Users\\user\\.gemini\\antigravity\\scratch\\hybrid-recommender')
```

**After:**
```python
if __name__ == '__main__':
    repo_root = pathlib.Path(__file__).parent
    scan_dir(str(repo_root))
```

## Related issue

Closes #1499

## Type of change

- [x] Bug fix

## How to test this

```bash
# From the repo root
python scan.py
# Should now print security pattern matches found in the actual codebase
# Previously produced zero output (was scanning a nonexistent path)
```

## Screenshots (if UI change)

N/A — CLI tool fix. Running `python scan.py` now produces real output from the repo instead of silent empty results.