### PR TITLE
fix: add Redis and Celery worker services to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,39 @@
 version: "3.9"
 
 services:
+  # ── Redis (message broker + result backend + response cache) ──────────────
+  redis:
+    image: redis:7-alpine
+    container_name: hybridrec-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - hybridrec
+
+  # ── Celery worker (async model rebuild + recommendation tasks) ────────────
+  celery-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hybridrec-celery
+    command: celery -A celery_app worker --loglevel=info --concurrency=2
+    env_file:
+      - .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - hybridrec
+
   # ── Backend ──────────────────────────────────────────────────────────────
   backend:
     build:
@@ -11,8 +44,13 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./datasets:/app/datasets:ro   # mount datasets/ read-only
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c",


### PR DESCRIPTION
## What does this PR do?

Adds the missing `redis` and `celery-worker` services to `docker-compose.yml`. Without these, `docker compose up` produces a silently degraded stack — Redis is unreachable, so `dispatch_task_safely()` falls back to synchronous inline execution for every async task and logs a warning on every request.

**Services added:**

| Service | Image | Purpose |
|---------|-------|---------|
| `redis` | `redis:7-alpine` | Message broker, Celery result backend, response cache |
| `celery-worker` | project Dockerfile | Processes async model rebuild and recommendation tasks |

**Key decisions:**
- Both `backend` and `celery-worker` override `REDIS_URL` to `redis://redis:6379/0` (the Compose service name) rather than `localhost`, which would not resolve inside the container network
- `backend` and `celery-worker` both declare `depends_on: redis: condition: service_healthy` so they only start after Redis is accepting connections
- Celery worker uses `--concurrency=2` as a safe default for CPU-bound ML work (can be tuned via environment variable if needed)
- Redis healthcheck uses `redis-cli ping` — the standard approach

## Related issue

Closes #1500

## Type of change

- [x] Bug fix

## How to test this

```bash
cp .env.example .env
# Fill in SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_KEY

docker compose up --build

# Verify Redis is up
docker compose exec redis redis-cli ping
# Expected: PONG

# Verify Celery worker connected
docker compose logs celery-worker | grep "ready"
# Expected: celery@... ready.

# Trigger a model rebuild and check it runs asynchronously
curl -X POST http://localhost:8000/api/build
# Backend logs should NOT contain the "Degrading gracefully" warning
```

## Screenshots (if UI change)

N/A — infrastructure change only.