### PR TITLE
Delete package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,1 @@
-{
-  "name": "hybrid-recommender",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}
+


### PR DESCRIPTION
### Description
Removed the orphaned `package-lock.json` files from the root, `frontend/`, and `backend/` directories. These lockfiles did not have matching `package.json` manifests, making it impossible to run `npm install` or accurately track dependencies.

### Closes
Closes #1496