### PR TITLE
Add GitHub Discussions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ![Coverage](https://img.shields.io/badge/coverage-50%25-brightgreen)
 [![Live Demo](https://shields.io)](https://vercel.app)
-
+[![GitHub Discussions](https://shields.io)](https://github.com)
 
 <div align="center">
 


### PR DESCRIPTION
### Description
This PR addresses #233 by adding the GitHub Discussions badge and link to the README. Since settings access is restricted to maintainers, I have prepared the required starter threads below for you to easily copy, paste, and publish once you enable the Discussions feature.

### Required Maintainer Actions (Post-Merge)
1. Go to **Settings** -> **Features** -> Check **Discussions**.
2. Create and publish the 4 starter threads below.
3. Pin the "Introduce yourself!" thread.

---

### 📋 Starter Thread Templates (For Maintainers)

#### Thread 1: General Category (PIN THIS ONE)
* **Title:** 👋 Introduce yourself!
* **Body:** 
Welcome to the hybrid-recommender community! We are excited to have you here. 

Take a moment to introduce yourself to the team and fellow contributors:
- What is your name or background?
- What interested you about this project?
- What are you hoping to learn or contribute?

#### Thread 2: Ideas Category
* **Title:** 💡 Feature ideas for hybrid-recommender
* **Body:**
Have a brilliant idea to improve our recommendation algorithms or frontend? Share it here! 

Please include:
- A clear description of your proposed feature.
- Why you think it would benefit the project.
- Any technical implementation ideas you have.

#### Thread 3: Q&A Category
* **Title:** ❓ Getting started — ask your setup questions here
* **Body:**
Stuck setting up the project locally? Don't sweat it! 

Drop your setup questions, error logs, or environment doubts in this thread so the mentors and community can help you get up and running.

#### Thread 4: General Category
* **Title:** 🐛 Found a bug not in Issues? Report here
* **Body:**
If you notice minor glitches, typos, or unexpected behavior that doesn't quite warrant a formal issue tracker ticket yet, let us know right here! Please provide steps to reproduce the glitch if possible.
