### PR TITLE
fix: resolve NameError pagination crash on product list API 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1645,6 +1645,7 @@ def update_weights(w: WeightsUpdate) -> dict:
 def list_items(page: int = 1, per_page: int = 50) -> dict:
     """List products from Supabase with pagination."""
     sb = get_supabase()
+    limit = per_page
     offset = (page - 1) * limit
     result = sb.table('products').select('id, title, description, category, rating, avg_sentiment, review_count').order('rating', desc=True).range(offset, offset + limit - 1).execute()
     count_result = sb.table('products').select('id', count='exact').limit(0).execute()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,3 +38,61 @@ def test_version_endpoint():
         "service": "Hybrid Recommender API",
         "status": "running",
     }
+
+
+def test_list_items_endpoint(monkeypatch):
+    from backend import main
+
+    class MockTable:
+        def __init__(self, name):
+            self.name = name
+            self.data = []
+            self.count = 100
+
+        def select(self, fields, count=None):
+            return self
+
+        def order(self, field, desc=True):
+            return self
+
+        def range(self, start, end):
+            self.data = [
+                {
+                    'id': i,
+                    'title': f'Product {i}',
+                    'category': 'Electronics',
+                    'rating': 4.5,
+                    'avg_sentiment': 0.8,
+                    'description': 'Description'
+                }
+                for i in range(start, min(end + 1, 100))
+            ]
+            return self
+
+        def limit(self, limit_val):
+            return self
+
+        def execute(self):
+            class Result:
+                def __init__(self, data, count):
+                    self.data = data
+                    self.count = count
+            return Result(self.data, self.count)
+
+    class MockSupabase:
+        def table(self, name):
+            return MockTable(name)
+
+    monkeypatch.setattr(main, "get_supabase", lambda: MockSupabase())
+
+    # Call with page=2 and per_page=10
+    response = client.get("/api/items?page=2&per_page=10")
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert len(data["items"]) == 10
+    assert data["total"] == 100
+    assert data["page"] == 2
+    assert data["limit"] == 10
+    assert data["has_more"] is True
+


### PR DESCRIPTION
### Description
Fixes a `NameError` crash in the `/api/items` product list pagination.

### Details
In [backend/main.py](file:///d:/hybrid-recommender/hybrid-recommender/backend/main.py)'s [list_items](file:///d:/hybrid-recommender/hybrid-recommender/backend/main.py#L1645) function, the pagination offset and database range calculations referenced a local variable named `limit`. However, the function parameter was declared as `per_page`, which led to a `NameError` when querying `/api/items?page=2&per_page=50`.

### Changes
- Defined `limit = per_page` inside the [list_items](file:///d:/hybrid-recommender/hybrid-recommender/backend/main.py#L1645) function. This resolves the mismatch while preserving API compatibility for queries using `per_page`.
- Added [test_list_items_endpoint](file:///d:/hybrid-recommender/hybrid-recommender/tests/test_api.py#L42) in [tests/test_api.py](file:///d:/hybrid-recommender/hybrid-recommender/tests/test_api.py) to cover query execution and pagination limits.