### PR TITLE
feat: harden realtime recommendation WebSocket flow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -323,7 +323,7 @@ def _get_cached_response(key: str):
             if cached is not None:
                 _cache_hits += 1
                 return json.loads(cached)
-        except (RedisError, json.JSONDecodeError):
+        except (RedisError, TypeError, json.JSONDecodeError):
             pass
 
     with _cache_lock:
@@ -1099,6 +1099,37 @@ class RealtimeRecommendationRequest(BaseModel):
     top_n: int = 10
     explain: bool = False
     target_catalog: Optional[str] = None
+
+class RealtimeClientEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(..., min_length=1, max_length=80)
+    payload: dict = Field(default_factory=dict)
+
+
+class RealtimeRecommendationPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_title: str = Field(..., min_length=1, max_length=500)
+    top_n: int = Field(10, ge=1, le=50)
+    explain: bool = False
+    user_id: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-zA-Z0-9_\-\.@]+$",
+    )
+
+
+def websocket_error(code: str, message: str):
+    return {
+        "type": "error",
+        "error": {
+            "code": code,
+            "message": message,
+        },
+        "message": message,
+    }
 
 
 # ── CSRF Token ───────────────────────────────────────────────────────
@@ -2268,35 +2299,102 @@ def get_user_recommendations(user_id: str, top_n: int = Query(10, ge=1, le=50), 
 @app.websocket("/ws/recommendations")
 async def websocket_recommendations(websocket: WebSocket):
     await realtime_hub.connect(websocket)
+
     try:
         while True:
-            data = await websocket.receive_json()
-            item_title = data.get("item_title")
-            top_n = data.get("top_n", 10)
-            explain = data.get("explain", False)
-            user_id = data.get("user_id")
+            try:
+                data = await websocket.receive_json()
+            except Exception:
+                await websocket.send_json(
+                    websocket_error("INVALID_JSON", "Message must be valid JSON.")
+                )
+                continue
 
-            if not models.get("ready") or not models.get("hybrid"):
+            if "type" not in data and "item_title" in data:
+                event_type = "recommendation_request"
+                payload_data = data
+            else:
+                try:
+                    event = RealtimeClientEvent.model_validate(data)
+                    event_type = event.type
+                    payload_data = event.payload
+                except Exception:
+                    await websocket.send_json(
+                        websocket_error("INVALID_EVENT", "Invalid realtime event format.")
+                    )
+                    continue
+
+            if event_type == "ping":
                 await websocket.send_json({
-                    "type": "error",
-                    "message": "Models not built yet."
+                    "type": "pong",
+                    "payload": {
+                        "status": "ok",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    },
                 })
                 continue
 
-            recs = models["hybrid"].recommend(item_title, user_id=user_id, top_n=top_n, explain=explain)
+            if event_type in {"subscribe", "unsubscribe"}:
+                await websocket.send_json({
+                    "type": "connection_status",
+                    "payload": {
+                        "status": event_type,
+                        "channel": payload_data.get("channel", "recommendations"),
+                    },
+                })
+                continue
+
+            if event_type != "recommendation_request":
+                await websocket.send_json(
+                    websocket_error("UNSUPPORTED_EVENT", f"Unsupported event type: {event_type}")
+                )
+                continue
+
+            try:
+                request_payload = RealtimeRecommendationPayload.model_validate(payload_data)
+            except Exception:
+                await websocket.send_json(
+                    websocket_error("INVALID_PAYLOAD", "Invalid recommendation request payload.")
+                )
+                continue
+
+            if not models.get("ready") or not models.get("hybrid"):
+                await websocket.send_json(
+                    websocket_error("MODEL_NOT_READY", "Models not built yet.")
+                )
+                continue
+
+            recs = models["hybrid"].recommend(
+                request_payload.item_title,
+                user_id=request_payload.user_id,
+                top_n=request_payload.top_n,
+                explain=request_payload.explain,
+            )
+
             await websocket.send_json({
                 "type": "recommendations",
-                "query_item": item_title,
-                "recommendations": recs
+                "query_item": request_payload.item_title,
+                "recommendations": recs,
+                "payload": {
+                    "query_item": request_payload.item_title,
+                    "recommendations": recs,
+                },
             })
+
     except WebSocketDisconnect:
         realtime_hub.disconnect(websocket)
     except Exception as e:
-        logger.error("WebSocket error: %s", e)
+        logger.exception("WebSocket error")
         try:
-            realtime_hub.disconnect(websocket)
+            await websocket.send_json({
+                "type": "error",
+                "message": str(e),
+            })
+            await websocket.close(code=1011)
         except Exception:
             pass
+        finally:
+            realtime_hub.disconnect(websocket)
 
 
 @app.post("/api/realtime/behavior")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -183,12 +183,18 @@
     <main class="main" id="main-content">
         <!-- Recommendations Strip -->
         <section class="recs-section" id="recs-section" hidden>
-            <h2 class="section-title">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
-                </svg>
-                Recommended for you
-            </h2>
+            <div class="section-header">
+                <h2 class="section-title">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                    </svg>
+                    Recommended for you
+                </h2>
+
+                <span id="realtime-status" class="realtime-status" data-status="offline">
+                    Offline
+                </span>
+            </div>
 
             <div class="recs-loader" id="recs-loader" hidden aria-live="polite" aria-label="Loading recommendations">
 

--- a/frontend/js/recommendations.js
+++ b/frontend/js/recommendations.js
@@ -18,69 +18,150 @@ let recommendationSocket = null;
 let realtimeReady = false;
 let realtimeFallbackTimer = null;
 let pendingRecommendationTitle = null;
+let reconnectTimer = null;
+let heartbeatTimer = null;
+let reconnectAttempts = 0;
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const HEARTBEAT_INTERVAL_MS = 25000;
+
+function setRealtimeStatus(status) {
+  const el = document.getElementById('realtime-status');
+  if (!el) return;
+
+  const labels = {
+    live: 'Live',
+    reconnecting: 'Reconnecting',
+    offline: 'Offline',
+  };
+
+  el.textContent = labels[status] || 'Offline';
+  el.dataset.status = status;
+}
+
+function startRealtimeHeartbeat() {
+  clearInterval(heartbeatTimer);
+
+  heartbeatTimer = setInterval(() => {
+    if (!recommendationSocket || !realtimeReady) return;
+
+    recommendationSocket.send(JSON.stringify({
+      type: 'ping',
+      payload: {},
+    }));
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+
+function stopRealtimeHeartbeat() {
+  clearInterval(heartbeatTimer);
+  heartbeatTimer = null;
+}
+
+
+function scheduleRealtimeReconnect() {
+  if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+    setRealtimeStatus('offline');
+    return;
+  }
+
+  setRealtimeStatus('reconnecting');
+
+  const delay = Math.min(1000 * 2 ** reconnectAttempts, 10000);
+  reconnectAttempts += 1;
+
+  clearTimeout(reconnectTimer);
+  reconnectTimer = setTimeout(() => {
+    recommendationSocket = null;
+    initRecommendationSocket();
+  }, delay);
+}
 
 export function initRecommendationSocket() {
   if (!('WebSocket' in window) || recommendationSocket) return;
 
   const socket = new WebSocket(getRealtimeUrl());
   recommendationSocket = socket;
+  setRealtimeStatus('reconnecting');
 
   socket.addEventListener('open', () => {
     realtimeReady = true;
+    reconnectAttempts = 0;
+    setRealtimeStatus('live');
+    startRealtimeHeartbeat();
   });
 
   socket.addEventListener('message', (event) => {
     try {
       const data = JSON.parse(event.data);
+
+      if (data.type === 'pong' || data.type === 'connection_status') {
+        setRealtimeStatus('live');
+        return;
+      }
+
       if (data.type === 'recommendations') {
-        renderRecommendations(data);
-      } else if (data.type === 'error') {
-        throw new Error(data.detail || 'Recommendation stream failed');
+        clearTimeout(realtimeFallbackTimer);
+        renderRecommendations(data.payload || data);
+        return;
+      }
+
+      if (data.type === 'error') {
+        throw new Error(data.error?.message || data.message || 'Realtime request failed');
       }
     } catch (err) {
-      console.warn('Realtime recommendation update failed:', err.message);
-      fallbackRecommendationRequest(pendingRecommendationTitle);
+      console.warn('Realtime recommendation update failed:', err);
+      if (pendingRecommendationTitle) {
+        fallbackRecommendationRequest(pendingRecommendationTitle);
+      }
     }
   });
 
   socket.addEventListener('close', () => {
     realtimeReady = false;
     recommendationSocket = null;
+    stopRealtimeHeartbeat();
+    scheduleRealtimeReconnect();
   });
 
   socket.addEventListener('error', () => {
     realtimeReady = false;
+    setRealtimeStatus('offline');
   });
 }
 
 function requestRealtimeRecommendations(title) {
-  if (!realtimeReady || !recommendationSocket) return false;
+  if (!realtimeReady || !recommendationSocket) {
+    return false;
+  }
 
   pendingRecommendationTitle = title;
-  const userId = getAnonymousUserId();
+
   recommendationSocket.send(JSON.stringify({
-    item_title: title,
-    top_n: 12,
-    user_id: userId,
+    type: 'recommendation_request',
+    payload: {
+      item_title: title,
+      top_n: 12,
+      explain: false,
+      user_id: getAnonymousUserId(),
+    },
   }));
+
   return true;
 }
 
 async function fallbackRecommendationRequest(title) {
   if (!title) return;
 
-  clearTimeout(realtimeFallbackTimer);
-  realtimeFallbackTimer = setTimeout(async () => {
-    try {
-      const data = await API.post('/api/realtime/behavior', {
-        item_title: title,
-        top_n: 12,
-      });
-      renderRecommendations(data);
-    } catch {
-      await loadRecommendationsOverHttp(title);
-    }
-  }, 250);
+  try {
+    const data = await API.post('/api/realtime/behavior', {
+      item_title: title,
+      top_n: 12,
+    });
+    renderRecommendations(data);
+  } catch {
+    await loadRecommendationsOverHttp(title);
+  }
 }
 
 /**
@@ -204,6 +285,16 @@ export async function loadRecommendations(title) {
 
   showLoadingBar();
 
+  const sentRealtime = requestRealtimeRecommendations(title);
+
+  if (sentRealtime) {
+    clearTimeout(realtimeFallbackTimer);
+    realtimeFallbackTimer = setTimeout(() => {
+      fallbackRecommendationRequest(title);
+    }, 2500);
+    return;
+  }
+
   try {
     const userId = getAnonymousUserId();
     const res = await fetch(
@@ -250,13 +341,27 @@ function escapeHtml(str) {
   }[c]));
 }
 
+async function getCsrfToken() {
+  const res = await fetch('/api/csrf-token');
+  if (!res.ok) throw new Error(`CSRF token request failed: ${res.status}`);
+
+  const data = await res.json();
+  return data.csrfToken;
+}
+
 const API = {
   async post(url, data) {
+    const csrfToken = await getCsrfToken();
+
     const res = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
       body: JSON.stringify(data),
     });
+
     if (!res.ok) throw new Error(`API error: ${res.status}`);
     return res.json();
   },

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2107,3 +2107,23 @@ RESPONSIVE FIX
     border-color: var(--accent-color, #007bff);
     transform: scale(1.05);
 }
+.realtime-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.realtime-status[data-status="live"] {
+  color: #16a34a;
+}
+
+.realtime-status[data-status="reconnecting"] {
+  color: #f59e0b;
+}
+
+.realtime-status[data-status="offline"] {
+  color: #ef4444;
+}

--- a/tests/test_realtime_recommendations.py
+++ b/tests/test_realtime_recommendations.py
@@ -62,11 +62,75 @@ def test_recommendations_websocket_streams_updates(realtime_client):
     assert len(payload["recommendations"]) == 2
     assert all(item["title"] != "Alpha" for item in payload["recommendations"])
 
+def test_recommendations_websocket_accepts_structured_event(realtime_client):
+    with realtime_client.websocket_connect("/ws/recommendations") as websocket:
+        websocket.send_json({
+            "type": "recommendation_request",
+            "payload": {"item_title": "Alpha", "top_n": 2},
+        })
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "recommendations"
+    assert payload["payload"]["query_item"] == "Alpha"
+    assert len(payload["payload"]["recommendations"]) == 2
+
+
+def test_recommendations_websocket_rejects_invalid_payload(realtime_client):
+    with realtime_client.websocket_connect("/ws/recommendations") as websocket:
+        websocket.send_json({
+            "type": "recommendation_request",
+            "payload": {"top_n": 2},
+        })
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "error"
+    assert payload["error"]["code"] == "INVALID_PAYLOAD"
+
+
+def test_recommendations_websocket_rejects_invalid_top_n(realtime_client):
+    with realtime_client.websocket_connect("/ws/recommendations") as websocket:
+        websocket.send_json({
+            "type": "recommendation_request",
+            "payload": {"item_title": "Alpha", "top_n": 500},
+        })
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "error"
+    assert payload["error"]["code"] == "INVALID_PAYLOAD"
+
+
+def test_recommendations_websocket_ping_pong(realtime_client):
+    with realtime_client.websocket_connect("/ws/recommendations") as websocket:
+        websocket.send_json({"type": "ping", "payload": {}})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "pong"
+    assert payload["payload"]["status"] == "ok"
+
+
+def test_recommendations_websocket_rejects_unsupported_event(realtime_client):
+    with realtime_client.websocket_connect("/ws/recommendations") as websocket:
+        websocket.send_json({"type": "unknown_event", "payload": {}})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "error"
+    assert payload["error"]["code"] == "UNSUPPORTED_EVENT"
+
+def post_with_csrf(client, url, payload):
+    token = "a" * 64
+    client.cookies.set("csrftoken", token)
+    return client.post(
+        url,
+        json=payload,
+        headers={"X-CSRF-Token": token},
+    )
+
 
 def test_realtime_behavior_endpoint_returns_http_fallback_payload(realtime_client):
-    response = realtime_client.post(
+    response = post_with_csrf(
+        realtime_client,
         "/api/realtime/behavior",
-        json={"item_title": "Alpha", "top_n": 2},
+        {"item_title": "Alpha", "top_n": 2},
     )
 
     assert response.status_code == 200
@@ -79,9 +143,10 @@ def test_realtime_behavior_endpoint_returns_http_fallback_payload(realtime_clien
 def test_realtime_behavior_requires_built_models(realtime_client):
     models["ready"] = False
 
-    response = realtime_client.post(
+    response = post_with_csrf(
+        realtime_client,
         "/api/realtime/behavior",
-        json={"item_title": "Alpha", "top_n": 2},
+        {"item_title": "Alpha", "top_n": 2},
     )
 
     assert response.status_code == 400

--- a/tests/test_realtime_recommendations.py
+++ b/tests/test_realtime_recommendations.py
@@ -118,11 +118,16 @@ def test_recommendations_websocket_rejects_unsupported_event(realtime_client):
 
 def post_with_csrf(client, url, payload):
     token = "a" * 64
+    origin = "http://testserver"
     client.cookies.set("csrftoken", token)
     return client.post(
         url,
         json=payload,
-        headers={"X-CSRF-Token": token},
+        headers={
+            "X-CSRF-Token": token,
+            "Origin": origin,
+            "Referer": f"{origin}/",
+        },
     )
 
 


### PR DESCRIPTION
## What does this PR do?

This PR hardens the existing realtime recommendation flow around the `/ws/recommendations` WebSocket endpoint and the `/api/realtime/behavior` HTTP fallback route.

The implementation focuses on making the realtime transport safer, more predictable, and more production-ready by adding structured WebSocket events, payload validation, heartbeat support, reconnect-safe frontend behavior, visible connection status, CSRF-safe fallback requests, and expanded test coverage.

Closes #1284

## Backend Changes

### Structured WebSocket event handling

The `/ws/recommendations` endpoint now supports structured realtime events instead of only accepting raw recommendation payloads.

Supported event types:
- `recommendation_request`
- `ping`
- `subscribe`
- `unsubscribe`

The new structured format is:

```json
{
  "type": "recommendation_request",
  "payload": {
    "item_title": "Alpha",
    "top_n": 2,
    "explain": false,
    "user_id": "optional-user-id"
  }
}
```

### Backward compatibility

The endpoint still supports the older payload format:

```json
{
  "item_title": "Alpha",
  "top_n": 2
}
```

This keeps the existing realtime behavior working while allowing the frontend to move to the new structured event contract.

### Payload validation

Added validation for realtime recommendation payloads:
- `item_title` is required.
- `top_n` is bounded to prevent overly large requests.
- `explain` is supported as an optional boolean.
- `user_id` is optional and validated against a safe pattern.
- Unknown/invalid payload shapes return structured errors instead of failing silently.

### Structured error responses

The WebSocket endpoint now returns structured error messages for invalid or unsupported client input.

Handled cases include:
- Invalid JSON
- Invalid event format
- Invalid recommendation payload
- Unsupported event type
- Model-not-ready state

Example error response:

```json
{
  "type": "error",
  "error": {
    "code": "INVALID_PAYLOAD",
    "message": "Invalid recommendation request payload."
  },
  "message": "Invalid recommendation request payload."
}
```

### Ping/pong heartbeat support

Added `ping` event support so the frontend can keep the connection alive and verify that the realtime channel is still responsive.

Example request:

```json
{
  "type": "ping",
  "payload": {}
}
```

Example response:

```json
{
  "type": "pong",
  "payload": {
    "status": "ok",
    "timestamp": "..."
  }
}
```

### Better WebSocket exception handling

Previously, backend exceptions inside the WebSocket flow could cause the client/test to wait indefinitely for a response.

This PR improves the error path so unexpected WebSocket failures are logged and returned to the client as structured error responses before the socket is closed safely.

### Related realtime-path stability fixes

While enabling the realtime tests, a few existing issues were found in the recommendation path and fixed because they were blocking the realtime flow:
- Added missing Redis cache exception handling.
- Fixed content recommendation deduplication where an undefined `key` variable caused runtime failures.
- Fixed content score usage to rely on the loop score instead of a possibly unavailable `scores` variable.
- Fixed broken bandit method indentation in the hybrid recommender.
- Fixed CSRF handling in realtime fallback tests.


## Frontend Changes

### Structured realtime recommendation requests

The frontend now sends WebSocket recommendation requests using the structured event format:

```json
{
  "type": "recommendation_request",
  "payload": {
    "item_title": "...",
    "top_n": 12,
    "explain": false,
    "user_id": "..."
  }
}
```

### Heartbeat support

The frontend sends periodic `ping` events to keep the realtime connection active and detect connection health.

### Reconnect handling

Added bounded reconnect/backoff behavior for the recommendation WebSocket.

The frontend now handles:
- WebSocket open
- WebSocket close
- WebSocket error
- reconnect attempts
- heartbeat cleanup
- fallback behavior when realtime fails

### Realtime status UI

Added a small realtime status indicator in the recommendations section.

Supported states:
- `Live`
- `Reconnecting`
- `Offline`

This gives users visible feedback about the realtime recommendation connection state.

### HTTP fallback support

If the WebSocket path fails or does not return in time, the frontend falls back to the existing HTTP recommendation behavior.

The fallback POST request now includes CSRF token handling by fetching `/api/csrf-token` and sending the returned token in the `X-CSRF-Token` header.


## Tests Added / Updated

Updated `tests/test_realtime_recommendations.py` to cover both the existing behavior and the new hardened realtime flow.

Test coverage includes:

- Legacy WebSocket recommendation payload support
- Structured WebSocket recommendation event support
- Invalid recommendation payload rejection
- Invalid `top_n` rejection
- Ping/pong heartbeat behavior
- Unsupported WebSocket event rejection
- CSRF-protected HTTP fallback route
- Model-not-ready HTTP fallback response


## Testing Performed

Ran:

```bash
python -m pytest tests/test_realtime_recommendations.py -v
```

Result:

```text
8 passed, 5 warnings
```

Also ran:

```bash
git diff --check
```

Result:

```text
No whitespace errors reported.
```

Note: Git showed CRLF/LF line-ending warnings on Windows, but there were no actual whitespace check failures.



## Why this change is useful

This improves the realtime recommendation system by making the WebSocket API more reliable and easier to extend.

Before this PR, the realtime flow accepted loosely shaped messages and could silently fail or leave the client waiting if an exception occurred.

After this PR:
- the message contract is explicit,
- invalid input is rejected clearly,
- the frontend can monitor connection health,
- users can see realtime connection status,
- reconnect behavior is safer,
- HTTP fallback remains available,
- and the realtime behavior is covered by tests.


## Checklist
- [x] Hardened existing `/ws/recommendations` endpoint
- [x] Preserved backward compatibility with existing payload format
- [x] Added structured WebSocket event support
- [x] Added payload validation
- [x] Added structured error responses
- [x] Added ping/pong heartbeat support
- [x] Added frontend reconnect/backoff handling
- [x] Added realtime status indicator
- [x] Added CSRF-safe HTTP fallback request
- [x] Added/updated realtime tests
- [x] Verified tests pass locally
