### PR TITLE
fix(backend): define missing CLEANUP_THRESHOLD and _request_counter g…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -151,6 +151,8 @@ from collections import OrderedDict
 _rate_limit_buckets = OrderedDict()
 _rate_limit_lock = Lock()
 MAX_RATE_LIMIT_IPS = 10000
+CLEANUP_THRESHOLD = 10000   # run stale-bucket cleanup every N requests
+_request_counter = 0
 
 _cache_lock = Lock()
 


### PR DESCRIPTION
Added CLEANUP_THRESHOLD = 10000 and _request_counter = 0 to the rate-limiter globals section. File: backend/main.py — 2 lines added.

closes #1516 