### PR TITLE
fix(backend): register recommend router with FastAPI app — all /recommendations/* routes were returning 404

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -114,6 +114,9 @@ from issue_triage import triage_issue
 # ── App ──────────────────────────────────────────────────────────────
 app = FastAPI(title="Hybrid Recommender API", version="3.0")
 
+# Register routers
+app.include_router(recommend.router, prefix="/api")
+
 # 🚀 DEGRADED MODE TELEMETRY TRACKER GLOBALS
 _model_degraded = False
 _model_degraded_reason: Optional[str] = None


### PR DESCRIPTION

Added app.include_router(recommend.router, prefix="/api") after app = FastAPI(...). File: backend/main.py — 3 lines added.

closes #1518 