### PR TITLE
fix(backend): remove duplicate CORS and CSRFMiddleware registration 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -925,20 +925,6 @@ def _get_feedback_storage_client():
     return client
 
 
-# CORS
-allowed_origins_env = os.environ.get("CORS_ORIGINS", "http://localhost:8000,http://127.0.0.1:8000")
-allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",")]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=allowed_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*", "X-CSRF-Token"],
-)
-
-app.add_middleware(CSRFMiddleware)
-
 # ── Response Time Monitoring ─────────────────────────────────────────
 SLOW_RESPONSE_THRESHOLD_MS = 500.0
 METRICS_SAMPLE_SIZE = 1000


### PR DESCRIPTION
Removed the second duplicate middleware block at lines 927–940. Middleware is now registered exactly once. File: backend/main.py — 14 lines deleted.

closes #1520 