### PR TITLE
fix(model): replace undefined 'key' with 't' in ContentRecommender.recommend() seen set

### DIFF
--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -100,7 +100,7 @@ class ContentRecommender:
             t = self.df.iloc[i]['title']
             if t.lower() == title.lower() or t in seen:
                 continue
-            seen.add(key)
+            seen.add(t)
             
             results.append({
                 "title": t,


### PR DESCRIPTION

Changed seen.add(key) to seen.add(t) on line 103. The duplicate-detection set now correctly tracks visited titles. File: src/model/content_model.py — 1 line changed.

closes #1524 