### PR TITLE
chore: add .gitignore patterns for developer scratch and draft files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,10 @@ requirements-dev.txt
 # macOS metadata
 .DS_Store
 **/.DS_Store
+
+# Developer scratch / draft files
+PR_DESCRIPTION_*.md
+old_*.py
+old_*.txt
+checks.json
+bug[0-9]*.md


### PR DESCRIPTION
## What does this PR do?

Adds `.gitignore` patterns to prevent accidental commits of developer scratch files, PR description drafts, backup scripts, and CI dumps.

**Patterns added:**

```
PR_DESCRIPTION_*.md
old_*.py
old_*.txt
checks.json
bug[0-9]*.md
```

These cover the naming conventions seen in previously committed artifact files without risking exclusion of any legitimate project files.

## Related issue

Closes #1503

## Type of change

- [x] Refactor

## How to test this

```bash
touch PR_DESCRIPTION_999.md
git status
# Should show PR_DESCRIPTION_999.md as ignored (not staged)
rm PR_DESCRIPTION_999.md
```

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested my changes locally
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it