### PR TITLE
fix(model): add missing TfidfVectorizer import and fix scores[i] unde…

### DIFF
--- a/src/model/content_model.py
+++ b/src/model/content_model.py
@@ -9,6 +9,7 @@ Optimizations:
 import numpy as np
 import pandas as pd
 from sentence_transformers import SentenceTransformer
+from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from src.model.validation import validate_recommendations
 
@@ -104,7 +105,7 @@ class ContentRecommender:
             
             results.append({
                 "title": t,
-                "content_score": float(scores[i])
+                "content_score": float(score)
             })
             
             if len(results) >= top_n:


### PR DESCRIPTION
When the HNSW ANN index path succeeds (lines 74–76), only sim_scores is set. The loop at line 107 then accesses scores[i] which was never defined in the ANN path, causing UnboundLocalError. The loop variable score from for i, score in sim_scores already holds the correct cosine similarity value and should be used directly.

closes #1568 