### PR TITLE
fix(backend): add missing urlsplit import to prevent NameError in _no…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ import math
 import secrets
 
 import json
+from urllib.parse import urlsplit
 from redis import Redis
 from redis.exceptions import RedisError
 


### PR DESCRIPTION
Added from urllib.parse import urlsplit to the import block in backend/main.py.

closes #1571 