### PR TITLE
fix: replace Ellipsis fallback with valid arguments

### DIFF
--- a/tests/test_hybrid_popularity_fallback.py
+++ b/tests/test_hybrid_popularity_fallback.py
@@ -7,7 +7,8 @@ class EmptyContentModel:
     def __init__(self, df):
         self.df = df
 
-    def recommend(self, title, top_n=10):
+    def recommend(self, title, top_n=10, target_catalog=None, **kwargs):
+        # Accept extra kwargs like `target_catalog` to match real ContentRecommender API
         return []
 
 
@@ -38,3 +39,18 @@ def test_popularity_fallback_excludes_source_title():
     titles = [rec["title"] for rec in recs]
     assert "Product C" not in titles
     assert titles[0] == "Product A"
+
+
+def test_empty_rerank_uses_popularity_fallback():
+    # Ensure recommend() gracefully falls back when no content candidates exist
+    hm = make_recommender()
+
+    # Content model returns no candidates (EmptyContentModel), so recommend should
+    # use the popularity fallback and not raise due to any placeholder arguments.
+    recs = hm.recommend("Totally Unknown Product 99999", top_n=2)
+
+    assert isinstance(recs, list)
+    assert len(recs) == 2
+    titles = [r["title"] for r in recs]
+    # The fallback should not include the unknown queried title
+    assert "Totally Unknown Product 99999" not in titles


### PR DESCRIPTION
## What changed

* Updated the `EmptyContentModel` test double in `tests/test_hybrid_popularity_fallback.py` to accept `target_catalog` and additional keyword arguments, matching the current recommender interface.
* Added a focused regression test (`test_empty_rerank_uses_popularity_fallback`) that verifies `HybridRecommender.recommend()` gracefully returns popularity-based fallback recommendations for an unknown query.
* Added assertions ensuring the returned recommendations are valid and that the queried title is not included in the fallback results.

## Why

The production fallback behavior is already implemented in the current codebase. However, this specific execution path was not covered by a dedicated regression test.

This PR strengthens the test suite by:

* covering the popularity fallback path for unknown queries,
* ensuring compatibility of the test double with the current API,
* helping prevent future regressions in fallback recommendation behavior.

## How to test

```bash
pytest tests/test_hybrid_popularity_fallback.py -v
```

Expected results:

* All tests pass successfully.
* `test_empty_rerank_uses_popularity_fallback` passes.
* The unknown-query recommendation path returns a valid popularity fallback list without errors.
## Notes

* This is a **test-only** PR.
* No production logic has been modified.
* The existing runtime behavior is preserved; this PR only improves regression coverage for the fallback recommendation path.

## Closes #1552 
