### PR TITLE
fix duplicate FastAPI app creation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -151,9 +151,6 @@ async def csrf_header_dep(
     # The middleware has already validated the token before this runs.
     # This function exists solely to make the header visible in Swagger UI.
 
-# ── App ──────────────────────────────────────────────────────────────
-app = FastAPI(title="Hybrid Recommender API", version="3.0")
-
 @app.on_event("startup")
 def download_nltk_assets():
     """

--- a/tests/test_fastapi_app_registration.py
+++ b/tests/test_fastapi_app_registration.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_backend_main_creates_single_fastapi_app():
+    source = Path("backend/main.py").read_text()
+
+    assert source.count("app = FastAPI(") == 1
+    assert source.index("app = FastAPI(") < source.index(
+        "app.include_router(recommend.router, prefix=\"/api\")"
+    )


### PR DESCRIPTION
## What changed
- Removed the second `app = FastAPI(...)` assignment from `backend/main.py`.
- Added a regression test that verifies `backend/main.py` creates the FastAPI app exactly once and registers the recommend router after that app is created.

## Why
The second app instantiation overwrote the earlier app object after `recommend.router` was registered, dropping `/api/recommend` routes and any app state attached before the overwrite.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_fastapi_app_registration.py -q`
- `git diff --check`

Note: `python3 -m py_compile backend/main.py` is still blocked by an existing indentation error in the interactions route that is already covered by PR #1610 / issue #1608.

Closes #1604