### PR TITLE
feat: TF-IDF vectorizer controls in Streamlit sidebar (Issue #1598)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -114,6 +114,32 @@ with st.sidebar:
         help="Maximum IPS weight cap. Prevents rare items from dominating.",
     )
 
+    # ── Issue #1598 — TF-IDF Vectorizer Controls ─────────────────────────
+    st.subheader("🔤 TF-IDF Vectorizer Settings")
+    st.caption("Tune the content-based TF-IDF vectorizer before building models.")
+
+    tfidf_ngram_min, tfidf_ngram_max = st.select_slider(
+        "N-gram Range",
+        options=[1, 2, 3],
+        value=(1, 2),
+        help="Minimum and maximum n-gram sizes. (1,1)=unigrams; (1,2)=unigrams+bigrams.",
+    )
+    tfidf_max_features = st.number_input(
+        "Max Features",
+        min_value=500,
+        max_value=50000,
+        value=10000,
+        step=500,
+        help="Maximum number of vocabulary features to keep.",
+    )
+    tfidf_stop_words = st.selectbox(
+        "Stop Words",
+        options=["english", "none"],
+        index=0,
+        help="Language for built-in stop-word list, or 'none' to keep all words.",
+    )
+    tfidf_stop_words_val = None if tfidf_stop_words == "none" else tfidf_stop_words
+
     st.subheader("⚖️ Hybrid Weights")
     st.caption("Weights are auto-normalised to sum to 1 by the model.")
 
@@ -225,8 +251,13 @@ else:
 
         with st.spinner("Building models — this may take a moment for large datasets…"):
             try:
-                # Content model (always built)
-                content_model = ContentRecommender(adapted_df)
+                # Content model (always built), using sidebar TF-IDF settings (Issue #1598)
+                content_model = ContentRecommender(
+                    adapted_df,
+                    ngram_range=(tfidf_ngram_min, tfidf_ngram_max),
+                    max_features=int(tfidf_max_features),
+                    stop_words=tfidf_stop_words_val,
+                )
 
                 # Collaborative model — requires more than one unique user
                 collab_model = None


### PR DESCRIPTION
### Related Issue
Closes #1598

### What changed
Added a **TF-IDF Vectorizer Settings** section to the Streamlit sidebar in `src/api/app.py`. Users can now configure:
- **N-gram Range** – select slide between (1,1), (1,2), or (1,3)
- **Max Features** – number input capped between 500 and 50,000 (default 10,000)
- **Stop Words** – dropdown to choose `english` or `none`

These settings are forwarded to `ContentRecommender(...)` at model-build time, so the TF-IDF matrix is always recomputed with the user-selected parameters.

### Why
The TF-IDF vectorizer was hardcoded with fixed parameters, offering no way to experiment with different vocabulary sizes or n-gram windows without modifying source code. Exposing these controls in the sidebar makes the app far more useful for both end-users and researchers tuning retrieval quality.

### How to test
1. Run `streamlit run src/api/app.py`
2. In the sidebar, open the **TF-IDF Vectorizer Settings** section.
3. Change **N-gram Range** to `(1, 3)` and **Max Features** to `5000`.
4. Upload a dataset and click **Build Models**.
5. Run a recommendation query — verify the results differ from defaults (they should, because a bigger n-gram vocabulary changes similarity scores).

### Affected Files
- `src/api/app.py` — sidebar TF-IDF controls + wired to `ContentRecommender` constructor

### Checklist
- [x] N-gram range, max features, and stop-words widgets added.
- [x] Parameters forwarded to `ContentRecommender` on model build.
- [x] Default values match the original hardcoded behaviour.
- [x] No breaking changes to existing sidebar layout.
