### PR TITLE
feat: Origin/Referer validation in CSRF middleware (Issue #1597)

### DIFF
--- a/backend/csrf.py
+++ b/backend/csrf.py
@@ -44,6 +44,17 @@ CSRF_HEADER_NAME = "x-csrf-token"          # HTTP headers are lowercased by Star
 CSRF_TOKEN_BYTES = 32                       # 256-bit token → 64 hex chars
 CSRF_COOKIE_MAX_AGE = 60 * 60 * 8          # 8 hours in seconds
 
+# Issue #1597 — Allowed origins for Origin/Referer validation.
+# Comma-separated list in CSRF_ALLOWED_ORIGINS env var (e.g. "http://localhost:3000,https://app.example.com").
+# Falls back to permissive mode (all origins allowed) when the var is not set so that
+# existing deployments are not broken.
+_raw_allowed = os.environ.get("CSRF_ALLOWED_ORIGINS", "").strip()
+ALLOWED_ORIGINS: set[str] = (
+    {o.rstrip("/") for o in _raw_allowed.split(",") if o.strip()}
+    if _raw_allowed
+    else set()
+)
+
 
 # ── Response schema ───────────────────────────────────────────────────────────
 
@@ -200,6 +211,31 @@ class CSRFMiddleware:
         if request.url.path in _EXEMPT_PATHS:
             await self._app(scope, receive, send)
             return
+
+        # 2.5 Issue #1597 — Validate Origin / Referer header against ALLOWED_ORIGINS.
+        # Only enforced when CSRF_ALLOWED_ORIGINS is explicitly configured; when the
+        # list is empty the check is skipped to preserve backward compatibility.
+        if ALLOWED_ORIGINS:
+            origin: str = (
+                request.headers.get("origin", "")
+                or request.headers.get("referer", "")
+            )
+            # Strip path from Referer so we compare scheme+host only.
+            from urllib.parse import urlparse
+            parsed_origin = urlparse(origin)
+            origin_base = f"{parsed_origin.scheme}://{parsed_origin.netloc}".rstrip("/")
+            if origin_base not in ALLOWED_ORIGINS:
+                logger.warning(
+                    "CSRF validation failed (origin not allowed) path=%s origin=%s",
+                    request.url.path,
+                    origin_base or "(none)",
+                )
+                response = JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF validation failed: origin not allowed."},
+                )
+                await response(scope, receive, send)
+                return
 
         # 3. Read the token from the inbound cookie header.
         #    request.cookies is a plain dict populated by Starlette from


### PR DESCRIPTION
### Related Issue
Closes #1597

### What changed
Strengthened the `CSRFMiddleware` in `backend/csrf.py` with **Origin / Referer header validation**:
- Added `ALLOWED_ORIGINS` constant populated from a new `CSRF_ALLOWED_ORIGINS` environment variable (comma-separated list of allowed scheme+host values, e.g. `http://localhost:3000,https://app.example.com`).
- Inserted a new validation step (2.5) in `CSRFMiddleware.__call__` that extracts the `Origin` header (falling back to `Referer`) and compares the scheme+host against `ALLOWED_ORIGINS`. Requests from unlisted origins are immediately rejected with a `403`.
- When `CSRF_ALLOWED_ORIGINS` is not set the check is skipped, preserving backward compatibility with existing deployments.
- The token minimum-length enforcement (64 hex chars) was already present (`CSRF_TOKEN_BYTES = 32`) and remains unchanged.

### Why
Without Origin/Referer validation a determined attacker who can set arbitrary headers could potentially bypass the double-submit cookie check in same-site but cross-origin contexts. Validating the request origin adds a second layer of defence aligned with OWASP CSRF prevention guidelines.

### How to test
1. Set `CSRF_ALLOWED_ORIGINS=http://localhost:3000` in your `.env`.
2. Send a `POST /api/recommend` request **without** an `Origin` or `Referer` header — expect `403 CSRF validation failed: origin not allowed.`
3. Send the same request with `Origin: http://localhost:3000` and a valid `X-CSRF-Token` — expect `200`.
4. With `CSRF_ALLOWED_ORIGINS` unset, verify all existing requests continue to pass (backward compatibility).

### Affected Files
- `backend/csrf.py` — added `ALLOWED_ORIGINS` constant and Origin/Referer validation step in middleware

### Checklist
- [x] `ALLOWED_ORIGINS` read from `CSRF_ALLOWED_ORIGINS` env var.
- [x] Origin/Referer checked before token comparison.
- [x] Backward compatible (no-op when env var is unset).
- [x] 403 with descriptive message returned on origin mismatch.
- [x] Minimum token length (64 chars) enforcement unchanged.
