### PR TITLE
feat: version-controlled VADER custom lexicon for slang (Issue #1595)

### DIFF
--- a/backend/nlp_engine.py
+++ b/backend/nlp_engine.py
@@ -1,5 +1,81 @@
-from sklearn.feature_extraction.text import TfidfVectorizer # type: ignore
-from sklearn.metrics.pairwise import cosine_similarity # type: ignore
+"""
+backend/nlp_engine.py — NLP processing utilities for the Hybrid Recommender.
+
+Issue #1595: Added VADER custom lexicon support for slang and informal language.
+The lexicon is loaded from config/vader_lexicon_custom.json at runtime and
+version-controlled so it can be reviewed and updated via PRs.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore
+from sklearn.metrics.pairwise import cosine_similarity  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# Path to the version-controlled custom VADER lexicon (Issue #1595)
+_LEXICON_PATH = Path(__file__).parent.parent / "config" / "vader_lexicon_custom.json"
+
+
+def load_vader_with_custom_lexicon():
+    """
+    Issue #1595 — Load VADER SentimentIntensityAnalyzer with a custom slang lexicon.
+
+    Reads polarity scores from config/vader_lexicon_custom.json and applies them
+    to the VADER analyser via make_custom_heuristics().  If the lexicon file is
+    missing or malformed, falls back to the standard VADER lexicon with a warning.
+
+    Returns:
+        vaderSentiment.SentimentIntensityAnalyzer: Configured analyser instance.
+    """
+    try:
+        from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+    except ImportError:
+        logger.warning(
+            "vaderSentiment not installed; custom lexicon loading skipped. "
+            "Install it with: pip install vaderSentiment"
+        )
+        return None
+
+    analyzer = SentimentIntensityAnalyzer()
+
+    if not _LEXICON_PATH.exists():
+        logger.warning(
+            "Custom VADER lexicon not found at %s. "
+            "Using default VADER lexicon.",
+            _LEXICON_PATH,
+        )
+        return analyzer
+
+    try:
+        with open(_LEXICON_PATH, "r", encoding="utf-8") as f:
+            custom_entries: dict = json.load(f)
+
+        if not isinstance(custom_entries, dict):
+            raise ValueError("Lexicon JSON must be a flat object {word: polarity_score}.")
+
+        # VADER's lexicon is a plain dict attribute; we update it in-place.
+        analyzer.lexicon.update(
+            {word: float(score) for word, score in custom_entries.items()}
+        )
+        logger.info(
+            "Loaded %d custom VADER lexicon entries from %s",
+            len(custom_entries),
+            _LEXICON_PATH,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to load custom VADER lexicon from %s: %s. "
+            "Falling back to default VADER lexicon.",
+            _LEXICON_PATH,
+            exc,
+        )
+
+    return analyzer
+
 
 class NLPEngine:
     """

--- a/config/vader_lexicon_custom.json
+++ b/config/vader_lexicon_custom.json
@@ -1,0 +1,22 @@
+{
+  "lit": 3.0,
+  "banger": 2.5,
+  "goat": 3.5,
+  "mid": -1.5,
+  "cringe": -2.5,
+  "fire": 3.0,
+  "slay": 2.0,
+  "bussin": 3.0,
+  "lowkey": 0.5,
+  "highkey": 1.5,
+  "no cap": 2.0,
+  "overrated": -2.0,
+  "underrated": 2.0,
+  "slept on": 1.5,
+  "hyped": 1.0,
+  "trash": -3.0,
+  "gem": 3.0,
+  "peak": 3.5,
+  "basic": -1.0,
+  "sus": -1.5
+}


### PR DESCRIPTION
### Related Issue
Closes #1595

### What changed
Implemented **VADER custom lexicon** support for slang and informal language (Issue #1595):

1. **`config/vader_lexicon_custom.json`** (new, version-controlled) — contains 20 slang entries with polarity scores (e.g. `"lit": 3.0`, `"trash": -3.0`, `"bussin": 3.0`). Being version-controlled means all changes go through PR review.

2. **`backend/nlp_engine.py`** — added `load_vader_with_custom_lexicon()` function that:
   - Loads the JSON lexicon from `config/vader_lexicon_custom.json`
   - Applies entries to `SentimentIntensityAnalyzer.lexicon` in-place
   - Gracefully falls back to the default VADER lexicon if the file is missing or malformed

### Why
The standard VADER lexicon was trained on formal English and Twitter text from ~2014. Modern user reviews contain slang (`"bussin"`, `"mid"`, `"slaps"`) that VADER scores neutrally or incorrectly, degrading sentiment-based recommendations. A version-controlled custom lexicon allows the team to improve coverage incrementally via PRs.

### How to test
```python
from backend.nlp_engine import load_vader_with_custom_lexicon

analyzer = load_vader_with_custom_lexicon()
# "lit" should score positive
scores = analyzer.polarity_scores("This book is totally lit!")
assert scores["compound"] > 0.5

# "trash" should score negative
scores = analyzer.polarity_scores("Completely trash, avoid this.")
assert scores["compound"] < -0.5
```

### Affected Files
- `config/vader_lexicon_custom.json` — **[NEW]** version-controlled slang lexicon
- `backend/nlp_engine.py` — `load_vader_with_custom_lexicon()` function added

### Checklist
- [x] JSON lexicon is version-controlled and human-readable.
- [x] `load_vader_with_custom_lexicon()` applies entries to VADER in-place.
- [x] Falls back gracefully if lexicon file is absent or malformed.
- [x] Logs a warning if `vaderSentiment` is not installed.
