### PR TITLE
security: remove public Supabase config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,10 +337,17 @@ Add `-v` to also remove named volumes if you want a completely clean state.
 
 ## 06 — API Reference
 
-**Retrieve frontend configuration (Supabase URL + anon key):**
-```http
-GET /api/config
-```
+GET    /api/status                   →  System status + product count
+GET    /api/search?q=...&limit=20    →  Full-text search (PostgreSQL FTS)
+POST   /api/upload                   →  Upload CSV/JSON dataset
+POST   /api/build                    →  Train TF-IDF, SVD, VADER models
+GET    /api/recommend/{title}        →  Hybrid recommendations for an item
+GET    /api/items?page=1&per_page=50 →  Paginated product listing
+GET    /api/categories               →  All available categories
+GET    /api/weights                  →  Current α, β, γ blend weights
+PUT    /api/weights                  →  Update blend weights live
+GET    /api/purchases/{user_id}      →  User purchase history
+POST   /api/purchases                →  Record a purchase event
 
 **Check if the API server is running:**
 ```http
@@ -427,7 +434,7 @@ NDCG@K       —  ranking quality (discounted cumulative gain)
 ## 07 — Security
 
 ```text
-✓  No hardcoded credentials — config served via /api/config
+✓  No hardcoded credentials — Supabase public config is injected at render time
 ✓  .env excluded from git via .gitignore
 ✓  CORS restricted to explicit configured origins; wildcard origins are rejected
 ✓  Row-Level Security (RLS) on all Supabase tables
@@ -782,5 +789,4 @@ Run:
 python scripts/generate_kg_embeddings.py
 
 ---
-
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -136,6 +136,8 @@ docker-compose down
 ---
 
 ### 8. Open the App
+The backend renders the frontend with your Supabase URL and anon key injected into the page, so there is no separate public `/api/config` endpoint.
+
 Navigate to: [http://localhost:8000](http://localhost:8000)
 
 ## Architecture

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,9 +70,7 @@ from typing import Any, Optional
 from dotenv import load_dotenv # type: ignore
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse, JSONResponse
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Any, Optional
+from fastapi.responses import HTMLResponse
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -1220,14 +1218,6 @@ def get_api_metrics():
 
 
 # ── Config ────────────────────────────────────────────────────────────
-@app.get("/api/config")
-def get_config():
-    return {
-        "supabase_url": os.environ.get("SUPABASE_URL", ""),
-        "supabase_anon_key": os.environ.get("SUPABASE_ANON_KEY", ""),
-    }
-
-
 # ── Status ────────────────────────────────────────────────────────────
 @app.get("/api/status")
 def status():
@@ -3171,3 +3161,14 @@ async def reset_user_preferences(request: Request):
         logger.error(f"Error resetting preferences for user {validated_user_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to reset user data.")
 
+    def _render_index_html() -> str:
+        index_path = os.path.join(frontend_dir, "index.html")
+        with open(index_path, "r", encoding="utf-8") as fh:
+            html = fh.read()
+
+        return html.replace("__SUPABASE_URL__", os.environ.get("SUPABASE_URL", "")) \
+            .replace("__SUPABASE_ANON_KEY__", os.environ.get("SUPABASE_ANON_KEY", ""))
+
+    @app.get("/")
+    def serve_frontend():
+        return HTMLResponse(_render_index_html())

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -97,12 +97,16 @@ let sbClient = null;
 
 async function initSupabase() {
     try {
-        const resp = await fetch('/api/config');
-        if (!resp.ok) return null;
-        const config = await resp.json();
+        const config = window.__HYBRIDREC_SUPABASE__ || {};
         const { createClient } = window.supabase || {};
-        if (createClient && config.supabase_url && config.supabase_anon_key) {
-            sbClient = createClient(config.supabase_url, config.supabase_anon_key);
+        const hasInjectedConfig =
+            config.supabaseUrl &&
+            config.supabaseAnonKey &&
+            config.supabaseUrl !== '__SUPABASE_URL__' &&
+            config.supabaseAnonKey !== '__SUPABASE_ANON_KEY__';
+
+        if (createClient && hasInjectedConfig) {
+            sbClient = createClient(config.supabaseUrl, config.supabaseAnonKey);
         }
     } catch (e) {
         console.warn('Supabase init skipped:', e.message);
@@ -2206,3 +2210,4 @@ function initFilterChips() {
         });
     });
 }
+document.addEventListener('DOMContentLoaded', init);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -380,6 +380,12 @@
         </div>
     </div>
 </div>
+    <script>
+        window.__HYBRIDREC_SUPABASE__ = {
+            supabaseUrl: "__SUPABASE_URL__",
+            supabaseAnonKey: "__SUPABASE_ANON_KEY__"
+        };
+    </script>
     <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #1403.

## What changed
- Removed the public `/api/config` JSON endpoint from `backend/main.py`.
- Render the frontend HTML with Supabase values injected server-side instead of fetching them over the network.
- Updated `frontend/app.js` to read injected config only when it is present.
- Added a small inline config object in `frontend/index.html` and documented the new render-time injection flow.

## Why
The app only needs the public Supabase URL and anon key to bootstrap the client. Serving them from a dedicated public API route makes the values trivially discoverable and unnecessary on the wire.

## How to test
- `python3 -m py_compile backend/main.py`
- `node --check frontend/app.js`
- `git diff --check`
- Start the app and confirm the page loads normally.
- Open the browser dev tools and verify there is no `/api/config` request during frontend bootstrap.

## Validation
- `python3 -m py_compile backend/main.py`
- `node --check frontend/app.js`
- `git diff --check`