### PR TITLE
fix: add missing faiss-cpu dependency to requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ bleach
 # Pre-commit hooks
 pre-commit>=3.7
 sentence-transformers>=2.2.2
+faiss-cpu>=1.7.4
 
 # Pre-commit hooks
 pre-commit>=3.7


### PR DESCRIPTION
fixes #1663

What Was Done
Created New Branch: Checked out the main branch, pulled the latest changes, and created a new branch fix/issue-1663.
Added Missing Dependency: Added faiss-cpu>=1.7.4 to 
requirements.txt
 to resolve the missing dependency for two_tower_retrieval.py and test_neural_retrieval.py.
Verified Functionality:
Installed faiss-cpu in the local environment and ran the tests.
Verified that tests/test_neural_retrieval.py now runs and passes successfully:
bash


pytest tests/test_neural_retrieval.py