### PR TITLE
fix: implement background cache cleanup to prevent OOM

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -299,6 +299,24 @@ def _clear_response_cache() -> None:
         _cache_hits = 0
         _cache_misses = 0
 
+import asyncio
+
+async def _cache_cleanup_worker():
+    while True:
+        await asyncio.sleep(60)  # Cleanup every 60 seconds
+        now = time.time()
+        expired_keys = []
+        with _cache_lock:
+            for key, (expires_at, _) in _response_cache.items():
+                if expires_at <= now:
+                    expired_keys.append(key)
+            for key in expired_keys:
+                _response_cache.pop(key, None)
+
+@app.on_event("startup")
+async def start_cache_cleanup():
+    asyncio.create_task(_cache_cleanup_worker())
+    logger.info("Background cache cleanup task started.")
 
 @app.get("/api/cache_metrics")
 def get_cache_metrics():


### PR DESCRIPTION
## Description
This PR resolves an Out-Of-Memory (OOM) vulnerability caused by unbounded growth in the `_response_cache` dictionary. 
Closes #1374
Previously, the global `_response_cache` only evicted expired entries if those specific keys were requested again. If a cached request URL was accessed once and never again, it remained in memory indefinitely, leading to an eventual memory exhaustion crash.

**Changes included:**
- Implemented an asynchronous background garbage collection task (`_cache_cleanup_worker()`) native to FastAPI's `asyncio` event loop.
- The worker sweeps the `_response_cache` every 60 seconds.
- Safely purges any stale keys that have outlived their TTL (`CACHE_TTL_SECONDS`), ensuring predictable and stable memory utilization.
- Registered the task directly to the application's `@app.on_event("startup")` lifecycle hook to avoid adding any new third-party dependencies (like `cachetools`).

## Related Issues
- Resolves the cache-related memory leak / OOM vulnerability.

## Type of Change
- [x] Bug Fix
- [x] Performance / Stability Improvement

## Testing
- [x] Verified the background worker starts successfully upon FastAPI initialization.
- [x] Confirmed the asynchronous worker acquires the `_cache_lock` safely and does not block API requests.
- [x] Ensured expired cache entries are actively `.pop()`'ed without requiring a subsequent client request.
