### PR TITLE
fix: use gin_trgm_ops for GIN trigram index

### DIFF
--- a/supabase/migrations/002_create_products_table.sql
+++ b/supabase/migrations/002_create_products_table.sql
@@ -19,7 +19,7 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- Task 2: Add GIN index on product titles for fast similarity lookups
 CREATE INDEX IF NOT EXISTS idx_products_title_trgm 
-    ON products USING gin (title pg_trgm_ops);
+    ON products USING gin (title gin_trgm_ops);
 
 
 -- =============================================================================


### PR DESCRIPTION
# Pull Request Description

## What Changed

* Replaced the invalid operator class `pg_trgm_ops` with `gin_trgm_ops` in the trigram GIN index definition.
* Updated the index creation statement to use the correct PostgreSQL `pg_trgm` operator class.
* Ensured compatibility with PostgreSQL/Supabase environments when creating trigram indexes for fuzzy search.

---

## Why

The existing migration attempted to create a GIN index using:

```sql
title pg_trgm_ops
```

However, PostgreSQL's `pg_trgm` extension provides the `gin_trgm_ops` operator class for GIN indexes. Using `pg_trgm_ops` causes migration failures and prevents the trigram index from being created successfully.

This issue blocks the setup of fuzzy search functionality and can cause database initialization errors in fresh environments.

---

## How to Test

1. Run the migration script on a PostgreSQL/Supabase instance with the `pg_trgm` extension enabled.
2. Verify that the migration completes successfully without operator class errors.
3. Confirm that the trigram index is created:

```sql
SELECT indexname
FROM pg_indexes
WHERE tablename = 'products';
```

4. Execute a fuzzy search query and verify that it works as expected.

---

## Related Issue

Closes #1579 
