### PR TITLE
fix(api): call register_exception_handlers so custom error shape is active

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3088,9 +3088,6 @@ async def reset_user_preferences(request: Request):
         # 3. Wipe out the internal memory cache
         _clear_response_cache()
 
-
-        global global_redis_client
-
         if _redis_client is not None:
             try:
                 # Find keys matching this user's recommendation cache pattern

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,6 +24,7 @@ else:
 # Fix the path mapping so internal src imports work perfectly
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
+from src.api.exceptions import register_exception_handlers
 from src.data.dataset_manager import DatasetManager
 from src.model.content_model import ContentRecommender
 from src.model.collaborative_model import CollaborativeRecommender
@@ -31,6 +32,7 @@ from src.model.hybrid_model import HybridRecommender
 from src.model.causal_config import CausalConfig
 
 app = FastAPI(title="Hybrid Recommender API")
+register_exception_handlers(app)
 
 
 class RecommendationRequest(BaseModel):

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,76 @@
+import os
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.api.exceptions import (
+    register_exception_handlers,
+    global_http_exception_handler,
+    validation_exception_handler,
+    global_exception_handler,
+)
+
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/trigger-http")
+    def trigger_http():
+        raise StarletteHTTPException(status_code=404, detail="Not found")
+
+    @app.post("/trigger-validation")
+    def trigger_validation(body: dict):
+        pass
+
+    return app
+
+
+def test_handlers_are_registered(test_app):
+    assert StarletteHTTPException in test_app.exception_handlers
+    assert RequestValidationError in test_app.exception_handlers
+
+
+def test_http_exception_unified_shape(test_app):
+    client = TestClient(test_app, raise_server_exceptions=False)
+    response = client.get("/trigger-http")
+    assert response.status_code == 404
+    body = response.json()
+    assert body.get("error") is True
+    assert body.get("status_code") == 404
+    assert isinstance(body.get("message"), str)
+    assert isinstance(body.get("detail"), str)
+
+
+def test_validation_error_detail_is_string(test_app):
+    """'detail' must be a string — the frontend toast reads it directly."""
+    client = TestClient(test_app, raise_server_exceptions=False)
+    # send an integer where a dict is expected to trigger RequestValidationError
+    response = client.post("/trigger-validation", json=42)
+    assert response.status_code == 422
+    body = response.json()
+    assert body.get("error") is True
+    assert body.get("status_code") == 422
+    assert isinstance(body.get("detail"), str), (
+        "detail must be a string so the frontend toast renders correctly"
+    )
+    assert isinstance(body.get("details"), list)
+
+
+def test_src_api_main_calls_register_exception_handlers():
+    """Verify the call-site exists in src/api/main.py without importing the full module."""
+    from pathlib import Path
+    source = Path("src/api/main.py").read_text()
+    assert "register_exception_handlers" in source, (
+        "register_exception_handlers must be imported and called in src/api/main.py"
+    )
+    assert "register_exception_handlers(app)" in source, (
+        "register_exception_handlers(app) call is missing from src/api/main.py"
+    )


### PR DESCRIPTION
## What does this PR do?

`register_exception_handlers()` in `src/api/exceptions.py` was never called. The three custom handlers (HTTP, validation, unhandled exception) were dead code — FastAPI was using its default serialization for every error case.

Result: validation errors returned `{"detail": [<pydantic array>]}` instead of `{"error": true, "status_code": 422, "message": "Validation Error", "detail": "..."}`. The frontend reads `response.detail` as a string for toast messages, so it was rendering `[object Object]` on any validation failure.

Fix: import `register_exception_handlers` and call it immediately after `app = FastAPI(...)` in `src/api/main.py`.

## Related issue

Closes #1698

## Type of change

- [x] Bug fix

## How to test this

```bash
python -m pytest tests/test_exception_handlers.py -v
```

All 4 tests pass. The key assertions:
- `StarletteHTTPException` and `RequestValidationError` handlers are present on the app
- HTTP exception response has `{"error": true, "status_code": ..., "message": "...", "detail": "..."}`
- Validation error `detail` is a `str`, not a list

## Screenshots (if UI change)

N/A