### PR TITLE
fix(model): remove duplicate metadata block and dead hybrid recomputation in recommend()

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3088,9 +3088,6 @@ async def reset_user_preferences(request: Request):
         # 3. Wipe out the internal memory cache
         _clear_response_cache()
 
-
-        global global_redis_client
-
         if _redis_client is not None:
             try:
                 # Find keys matching this user's recommendation cache pattern

--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -554,37 +554,6 @@ class HybridRecommender:
             avg_rating = float(self._rating_map.get(item["title"], 0.0) or 0.0)
             category = self._category_map.get(item["title"], "")
 
-            # Popularity as a proper fourth component weighted by delta.
-            # Weights a, b, g are re-normalized here to leave room for delta,
-            # guaranteeing hybrid_score in [0, 1].
-            popularity = self._popularity_map.get(item['title'], 0.5)
-            weight_sum = a + b + g + self.delta
-            if weight_sum <= 0:
-                weight_sum = 1.0
-            hybrid = (
-                (a * content_scores[i] +
-                 b * collab_scores[i] +
-                 g * sentiment_scores[i] +
-                 self.delta * popularity) / weight_sum
-            )
-            popularity_bonus = 0.05 * popularity
-            
-            # Enforce strict upper bound limit check
-            hybrid = min(1.0, hybrid_base + popularity_bonus)
-
-            # Lookup info from content model's df
-            row_data = self.content_model.df[
-                self.content_model.df['title'] == item['title']
-            ]
-            avg_rating = self._rating_map.get(item['title'], 0.0)
-            category = self._category_map.get(item['title'], '')
-            description = ''
-            top_reviews = []
-            if len(row_data) > 0:
-                description = str(row_data.iloc[0].get('description', ''))[:200]
-                tp = row_data.iloc[0].get('top_reviews', [])
-                top_reviews = tp if isinstance(tp, list) else []
-
             result = {
                 'title': item['title'],
                 'content_score': round(content_scores[i], 4),

--- a/tests/test_hybrid_duplicate_metadata.py
+++ b/tests/test_hybrid_duplicate_metadata.py
@@ -1,0 +1,67 @@
+"""
+Regression test for the duplicate metadata lookup block in HybridRecommender.recommend().
+
+The scoring loop previously had two back-to-back metadata lookup blocks:
+  - Block A (guarded): wrapped in hasattr + try/except, set description/top_reviews
+  - Block B (unguarded): directly accessed self.content_model.df without None guard,
+    then reset description = '' and top_reviews = [], discarding Block A's values
+
+Additionally, popularity_bonus and hybrid were computed three times — the last
+computation always won, making the intermediate ones dead code.
+
+This test file validates the fix at the source level since hybrid_model.py
+has a pre-existing IndentationError at line 221 (stray code inside
+select_bandit_arm) that prevents module import.
+"""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _get_recommend_source() -> str:
+    return Path("src/model/hybrid_model.py").read_text()
+
+
+def test_no_unguarded_df_access_after_guarded_block():
+    """The unguarded self.content_model.df[...] lookup that followed Block A must be gone."""
+    source = _get_recommend_source()
+    # Block B's unguarded pattern was:
+    #   row_data = self.content_model.df[\n        self.content_model.df['title'] == item['title']
+    assert "row_data = self.content_model.df[\n                self.content_model.df['title']" not in source, (
+        "Unguarded self.content_model.df access (Block B) is still present — "
+        "it crashes with AttributeError when content_model.df is None"
+    )
+
+
+def test_description_not_unconditionally_reset_after_guarded_fetch():
+    """description = '' must not appear after the guarded metadata block."""
+    source = _get_recommend_source()
+    # The bug pattern was: Block A sets description via try/except, then Block B resets it.
+    # Find the guarded block and ensure there's no bare "description = ''" after it.
+    guarded_end = source.find("except Exception:\n                    pass\n\n            avg_rating")
+    assert guarded_end != -1, "Could not locate guarded metadata block — structure may have changed"
+    after_guard = source[guarded_end:]
+    # description = '' should not appear before the result = { construction
+    result_dict_pos = after_guard.find("result = {")
+    assert result_dict_pos != -1, "Could not find result dict construction"
+    between = after_guard[:result_dict_pos]
+    assert "description = ''" not in between, (
+        "description = '' found after the guarded block — Block B still discarding Block A's value"
+    )
+
+
+def test_popularity_bonus_computed_once_per_item():
+    """popularity_bonus = 0.05 * popularity must appear exactly once inside the scoring loop."""
+    source = _get_recommend_source()
+    loop_start = source.find("for i, item in enumerate(items):")
+    assert loop_start != -1, "Could not find scoring loop"
+    # Find where the loop ends (next method definition or results.sort)
+    loop_end = source.find("results.sort(", loop_start)
+    assert loop_end != -1
+    loop_body = source[loop_start:loop_end]
+    count = loop_body.count("popularity_bonus = 0.05 * popularity")
+    assert count == 1, (
+        f"popularity_bonus computed {count} times per item — expected exactly 1"
+    )


### PR DESCRIPTION
## What does this PR do?

Inside `HybridRecommender.recommend()`, the per-item scoring loop had two back-to-back metadata lookup blocks and three redundant variable assignments.

**Duplicate hybrid computation:** `popularity`, `popularity_bonus`, and `hybrid` were each computed three times per item. The weighted formula using `weight_sum` (lines 561-569) was computed then immediately overwritten by `min(1.0, hybrid_base + popularity_bonus)` on line 573 — making the whole block dead code.

**Duplicate metadata lookup (Block B):** After Block A safely fetched `description` and `top_reviews` inside `hasattr + try/except`, Block B immediately followed and:
1. Reset `description = ''` and `top_reviews = []`, discarding Block A's values.
2. Accessed `self.content_model.df[...]` with no `None` guard. If `content_model.df` is `None`, this raises `AttributeError` on every recommendation call.
3. Re-fetched `avg_rating` and `category` from the same maps Block A already read.

Fix: remove Block B and the duplicate `popularity`/`hybrid` recomputations. Block A already correctly computes all variables consumed by the result dict.

## Related issue

Closes #1697

## Type of change

- [x] Bug fix

## How to test this

```bash
python -m pytest tests/test_hybrid_duplicate_metadata.py -v
```

Note: `hybrid_model.py` has a pre-existing `IndentationError` at line 221 (stray code inside `select_bandit_arm`) that prevents module import. Tests validate the fix via source text inspection, consistent with `tests/test_fastapi_app_registration.py`.