### PR TITLE
fix(security): verify Supabase JWT signature and expiry (#297)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,11 @@ SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here
 
 # Supabase Service Role Key (private, never expose in frontend)
-SUPABASE_SERVICE_KEY=your-service-role-key-here
+# Supabase JWT Secret (found in Supabase Dashboard → Settings → API → JWT Settings)
+# Required to verify the signature and expiry of access tokens issued by
+# Supabase Auth. Without this set, authenticated routes reject all
+# requests with a 500 rather than silently accepting unverified tokens.
+SUPABASE_JWT_SECRET=your-jwt-secret-here
 
 REDIS_URL=redis://localhost:6379/0
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,26 +1,100 @@
+"""Authentication dependencies for the FastAPI backend.
+
+Provides:
+    - Admin API key verification for admin-only endpoints.
+    - Supabase JWT verification (signature + expiry + audience) for
+      user-scoped endpoints.
+"""
+
 import os
 
-from fastapi import Header, HTTPException
-
+import jwt
+from fastapi import Header, HTTPException, Request
 
 ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY")
 
+SUPABASE_JWT_SECRET = os.environ.get("SUPABASE_JWT_SECRET", "").strip()
+SUPABASE_JWT_AUDIENCE = os.environ.get(
+    "SUPABASE_JWT_AUDIENCE", "authenticated"
+).strip()
+
+
+def _extract_bearer_token(value: str | None) -> str:
+    """Pull the raw token out of an Authorization: Bearer <token> header."""
+    if not value:
+        return ""
+    scheme, _, token = value.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def verify_supabase_jwt(token: str) -> dict:
+    """Verify a Supabase-issued access token.
+
+    Checks, in order:
+        1. The token is signed with our configured secret (HS256).
+        2. The `exp` claim has not passed.
+        3. The `aud` claim matches the expected audience.
+
+    Returns the decoded claims dict on success.
+    Raises HTTPException(401) on any verification failure.
+    """
+    if not SUPABASE_JWT_SECRET:
+        raise HTTPException(
+            status_code=500,
+            detail="SUPABASE_JWT_SECRET is not configured on the server.",
+        )
+
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing bearer token.")
+
+    try:
+        claims = jwt.decode(
+            token,
+            SUPABASE_JWT_SECRET,
+            algorithms=["HS256"],
+            audience=SUPABASE_JWT_AUDIENCE,
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token has expired.")
+    except jwt.InvalidAudienceError:
+        raise HTTPException(
+            status_code=401, detail="Token audience is invalid."
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=401, detail="Invalid authentication token."
+        )
+
+    return claims
+
+
+def get_current_user_id(request: Request) -> str:
+    """FastAPI dependency: verify the caller's JWT, return their user id."""
+    token = _extract_bearer_token(request.headers.get("authorization"))
+    claims = verify_supabase_jwt(token)
+
+    user_id = claims.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Token is missing a subject claim."
+        )
+
+    return user_id
+
 
 def _require_admin_access(x_admin_key: str = Header(default=None)):
-    """
-    Require a valid admin API key for protected endpoints.
-    """
-
+    """Require a valid admin API key for protected endpoints."""
     if not ADMIN_API_KEY:
         raise HTTPException(
             status_code=500,
-            detail="ADMIN_API_KEY is not configured on the server."
+            detail="ADMIN_API_KEY is not configured on the server.",
         )
 
     if x_admin_key != ADMIN_API_KEY:
         raise HTTPException(
-            status_code=403,
-            detail="Admin access required."
+            status_code=403, detail="Admin access required."
         )
 
     return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,7 +78,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from db import get_supabase, get_supabase_admin
-from backend.auth import _require_admin_access
+from backend.auth import _require_admin_access, get_current_user_id
 logging.basicConfig(
     level=logging.INFO,
     format="[%(levelname)s] %(asctime)s - %(message)s",
@@ -2245,9 +2245,20 @@ def recommend_cold_start(
 
 @app.get("/api/user_recommend")
 @app.get("/api/recommend/user/{user_id}")
-def get_user_recommendations(user_id: str, top_n: int = Query(10, ge=1, le=50), explain: bool = Query(False)):
-    """Get hybrid recommendations for a user."""
-    _validate_user_id(user_id)  # allowlist-validate before model lookup
+def get_user_recommendations(
+    user_id: str,
+    top_n: int = Query(10, ge=1, le=50),
+    explain: bool = Query(False),
+    authenticated_user_id: str = Depends(get_current_user_id),
+):
+    """Get hybrid recommendations for a user.
+
+    Requires a valid, unexpired Supabase bearer token (see issue #297).
+    A caller may only request recommendations for their own user_id.
+    """
+    _validate_user_id(user_id)
+    if authenticated_user_id != user_id:
+        raise HTTPException(status_code=403, detail="Cannot access another user's recommendations.")
     if not models.get("ready") or not models.get("hybrid"):
         raise HTTPException(400, "Models not built. Build first via /api/build.")
     
@@ -2573,8 +2584,15 @@ def log_interaction(data: InteractionCreate):
 
 # ── Purchases ─────────────────────────────────────────────────────────
 @app.get("/api/purchases/{user_id}")
-def get_user_purchases(user_id: str, limit: int = Query(50, ge=1, le=200)):
-    _validate_user_id(user_id)  # allowlist-validate before any DB call
+def get_user_purchases(
+    user_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    authenticated_user_id: str = Depends(get_current_user_id),
+):
+    """Requires a valid, unexpired Supabase bearer token (see issue #297)."""
+    _validate_user_id(user_id)
+    if authenticated_user_id != user_id:
+        raise HTTPException(status_code=403, detail="Cannot access another user's purchase history.")
     sb = get_supabase()
     result = (
         sb.table('purchases')
@@ -2929,19 +2947,18 @@ class SearchRequest(BaseModel):
 
 # ── CLEAR USER PREFERENCES & RESET CACHE ENDPOINT ───────────────────
 @app.post("/api/v1/user/preferences/reset", dependencies=[Depends(csrf_header_dep)])
-async def reset_user_preferences(request: Request):
+async def reset_user_preferences(
+    request: Request,
+    validated_user_id: str = Depends(get_current_user_id),
+):
     """
     Clears the user interaction weights/history from Supabase 
     and wipes the local/Redis recommendation cache for that user.
+
+    Identity comes from a verified, unexpired Supabase bearer token
+    (see issue #297) rather than a caller-supplied x-user-id header,
+    which could be set to any value.
     """
-    # 1. Authentic/Validate user (In production, replace with your real auth dependency)
-    user_id = request.headers.get("x-user-id")
-    if not user_id:
-        raise HTTPException(status_code=400, detail="Missing x-user-id header.")
-    
-    # Securely validate the user ID format
-    validated_user_id = _validate_user_id(user_id)
-    
     try:
         # 2. Connect to Supabase and delete preference entries
         supabase = get_supabase_admin()
@@ -2974,4 +2991,3 @@ async def reset_user_preferences(request: Request):
     except Exception as e:
         logger.error(f"Error resetting preferences for user {validated_user_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to reset user data.")
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ uvicorn[standard]>=0.24.0
 nltk>=3.8.0
 python-multipart>=0.0.6
 supabase>=2.5.0
+PyJWT>=2.7.0
 tqdm>=4.66.0
 scipy>=1.11.0
 streamlit>=1.28.0

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,230 @@
+"""
+tests/test_jwt_auth.py — Tests for Supabase JWT verification (issue #297).
+
+Background: the backend previously had NO JWT verification at all.
+Routes like /api/recommend/user/{user_id} and /api/purchases/{user_id}
+trusted whatever user_id appeared in the URL, and /api/v1/user/preferences/reset
+trusted a plain (spoofable) x-user-id header. Supabase's own access tokens
+already carry a real `exp` claim and are refreshed client-side — the gap
+was that the backend never checked the signature or expiry at all.
+
+Covers:
+  - A validly-signed, unexpired token is accepted and its `sub` returned.
+  - An expired token is rejected with 401 (the literal bug in #297).
+  - A token signed with the wrong secret (forged/tampered) is rejected with 401.
+  - A token missing the `Authorization` header is rejected with 401.
+  - A token with the wrong `aud` claim is rejected with 401.
+  - A token missing the `sub` claim is rejected with 401.
+  - Misconfiguration (no SUPABASE_JWT_SECRET set) fails closed with 500,
+    never by silently accepting unverified tokens.
+  - An authenticated route only serves the token's own user_id (ownership
+    check), rejecting requests for another user's data with 403.
+"""
+
+import os
+import time
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TESTING", "true")
+
+TEST_SECRET = "test-supabase-jwt-secret-for-unit-tests-only"
+
+# Set this before importing backend.auth so the module-level
+# SUPABASE_JWT_SECRET constant picks it up.
+os.environ["SUPABASE_JWT_SECRET"] = TEST_SECRET
+os.environ["SUPABASE_JWT_AUDIENCE"] = "authenticated"
+
+from backend import auth as auth_module  # noqa: E402  (after env setup)
+
+
+def _make_token(
+    sub: str = "user_123",
+    secret: str = TEST_SECRET,
+    aud: str = "authenticated",
+    expires_in_seconds: int = 3600,
+    algorithm: str = "HS256",
+) -> str:
+    """Build a Supabase-shaped JWT for testing."""
+    now = int(time.time())
+    payload = {
+        "sub": sub,
+        "aud": aud,
+        "iat": now,
+        "exp": now + expires_in_seconds,
+        "role": "authenticated",
+    }
+    return jwt.encode(payload, secret, algorithm=algorithm)
+
+
+@pytest.fixture(autouse=True)
+def _reset_secret():
+    """Ensure each test starts from the same known-good secret/audience."""
+    auth_module.SUPABASE_JWT_SECRET = TEST_SECRET
+    auth_module.SUPABASE_JWT_AUDIENCE = "authenticated"
+    yield
+    auth_module.SUPABASE_JWT_SECRET = TEST_SECRET
+    auth_module.SUPABASE_JWT_AUDIENCE = "authenticated"
+
+
+# ── Unit tests: verify_supabase_jwt ────────────────────────────────────────────
+
+def test_valid_unexpired_token_is_accepted():
+    token = _make_token(sub="user_abc", expires_in_seconds=3600)
+    claims = auth_module.verify_supabase_jwt(token)
+    assert claims["sub"] == "user_abc"
+
+
+def test_expired_token_is_rejected_with_401():
+    """The literal bug reported in #297: an expired token must not be accepted."""
+    token = _make_token(sub="user_abc", expires_in_seconds=-60)  # expired 60s ago
+    with pytest.raises(Exception) as exc_info:
+        auth_module.verify_supabase_jwt(token)
+    assert getattr(exc_info.value, "status_code", None) == 401
+    assert "expired" in str(exc_info.value.detail).lower()
+
+
+def test_token_signed_with_wrong_secret_is_rejected():
+    """A forged/tampered token (wrong signing key) must be rejected, not just expiry."""
+    token = _make_token(sub="user_abc", secret="some-other-secret-entirely")
+    with pytest.raises(Exception) as exc_info:
+        auth_module.verify_supabase_jwt(token)
+    assert getattr(exc_info.value, "status_code", None) == 401
+
+
+def test_token_with_wrong_audience_is_rejected():
+    token = _make_token(sub="user_abc", aud="some-other-audience")
+    with pytest.raises(Exception) as exc_info:
+        auth_module.verify_supabase_jwt(token)
+    assert getattr(exc_info.value, "status_code", None) == 401
+
+
+def test_missing_token_is_rejected():
+    with pytest.raises(Exception) as exc_info:
+        auth_module.verify_supabase_jwt("")
+    assert getattr(exc_info.value, "status_code", None) == 401
+
+
+def test_token_missing_sub_claim_is_rejected_by_get_current_user_id():
+    now = int(time.time())
+    payload = {"aud": "authenticated", "iat": now, "exp": now + 3600}
+    token = jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    def whoami(user_id: str = Depends(auth_module.get_current_user_id)):
+        return {"user_id": user_id}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+
+
+def test_misconfigured_secret_fails_closed_not_open():
+    """If SUPABASE_JWT_SECRET is unset, we must refuse to verify (500),
+    never silently treat the token as valid."""
+    auth_module.SUPABASE_JWT_SECRET = ""
+    token = _make_token(sub="user_abc")
+    with pytest.raises(Exception) as exc_info:
+        auth_module.verify_supabase_jwt(token)
+    assert getattr(exc_info.value, "status_code", None) == 500
+
+
+# ── Integration tests: get_current_user_id as a FastAPI dependency ────────────
+
+@pytest.fixture()
+def whoami_app():
+    """A minimal app exercising get_current_user_id exactly as backend/main.py does."""
+    app = FastAPI()
+
+    @app.get("/whoami")
+    def whoami(user_id: str = Depends(auth_module.get_current_user_id)):
+        return {"user_id": user_id}
+
+    return app
+
+
+@pytest.fixture()
+def whoami_client(whoami_app):
+    with TestClient(whoami_app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_dependency_returns_subject_for_valid_token(whoami_client):
+    token = _make_token(sub="user_42")
+    response = whoami_client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "user_42"
+
+
+def test_dependency_rejects_expired_token(whoami_client):
+    token = _make_token(sub="user_42", expires_in_seconds=-1)
+    response = whoami_client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+
+
+def test_dependency_rejects_missing_authorization_header(whoami_client):
+    response = whoami_client.get("/whoami")
+    assert response.status_code == 401
+
+
+def test_dependency_rejects_non_bearer_scheme(whoami_client):
+    token = _make_token(sub="user_42")
+    response = whoami_client.get("/whoami", headers={"Authorization": f"Token {token}"})
+    assert response.status_code == 401
+
+
+# ── Ownership check pattern used in backend/main.py routes ────────────────────
+
+@pytest.fixture()
+def owned_resource_app():
+    """
+    Mirrors the pattern used in get_user_recommendations / get_user_purchases:
+    the path user_id must match the verified token's subject, or 403.
+    """
+    app = FastAPI()
+
+    @app.get("/resource/{user_id}")
+    def get_resource(user_id: str, authenticated_user_id: str = Depends(auth_module.get_current_user_id)):
+        if authenticated_user_id != user_id:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=403, detail="Cannot access another user's data.")
+        return {"user_id": user_id, "data": "secret"}
+
+    return app
+
+
+@pytest.fixture()
+def owned_resource_client(owned_resource_app):
+    with TestClient(owned_resource_app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_user_can_access_own_resource(owned_resource_client):
+    token = _make_token(sub="user_42")
+    response = owned_resource_client.get(
+        "/resource/user_42", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+
+
+def test_user_cannot_access_another_users_resource(owned_resource_client):
+    token = _make_token(sub="user_42")
+    response = owned_resource_client.get(
+        "/resource/someone_else", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 403
+
+
+def test_expired_token_cannot_access_resource_even_if_ids_match(owned_resource_client):
+    """Belt-and-suspenders: even a correct user_id match must not bypass expiry."""
+    token = _make_token(sub="user_42", expires_in_seconds=-1)
+    response = owned_resource_client.get(
+        "/resource/user_42", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    


### PR DESCRIPTION
## What changed

Added Supabase JWT verification to `backend/auth.py` and wired it into three previously-unauthenticated routes in `backend/main.py`:
- `verify_supabase_jwt()` — decodes the bearer token with PyJWT against `SUPABASE_JWT_SECRET` (HS256), checking signature, `exp` (expiry), and `aud` (audience) in one call
- `get_current_user_id()` — FastAPI dependency that extracts the bearer token, verifies it, and returns the token's `sub` claim
- Applied `Depends(get_current_user_id)` to `get_user_recommendations`, `get_user_purchases`, and `reset_user_preferences`
- Added an ownership check on the first two (token's user must match the requested `user_id`, else 403)
- Replaced the spoofable `x-user-id` header in `reset_user_preferences` with the verified token identity
- Documented the new required `SUPABASE_JWT_SECRET` env var in `.env.example`
- Added `PyJWT>=2.7.0` to `requirements.txt`

## Why

The backend had no JWT verification anywhere. Routes accepted `user_id` straight from the URL path or an `x-user-id` header with no signature or expiry check at all — so any caller could request another user's recommendations or purchase history, and an expired or entirely forged token would have been accepted just as easily as a valid one, since nothing ever opened the token to look.

## How to test

```
pip install -r requirements.txt
pytest tests/test_jwt_auth.py -v
```
14 tests, all passing — covers valid tokens, expired tokens, wrong signature, wrong audience, missing/malformed headers, fail-closed behavior when `SUPABASE_JWT_SECRET` is unset, and cross-user ownership checks.

## Screenshots
N/A — no UI changes.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows PEP8 style (`flake8 .`)
- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I can explain every line of code I've written
- [x] I have NOT used AI-generated code without understanding and attributing it

## Related issue
Closes #297

## AI assistance disclosure
- [x] I used AI assistance (Claude) to draft the JWT verification logic and accompanying tests, after identifying the missing auth check by reviewing the codebase myself. I reviewed, tested, and understand the implementation.