### PR TITLE
fix: replace datetime.utcnow() with datetime.now(timezone.utc) (close…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2639,7 +2639,7 @@ def get_trending_products(
     global TRENDING_CACHE
 
     # Cache for 1 hour
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     cache_key = (days, limit)
     if isinstance(TRENDING_CACHE, dict) and "data" in TRENDING_CACHE and TRENDING_CACHE["data"] is None:


### PR DESCRIPTION
Fixes #956

## Summary

`datetime.utcnow()` is deprecated since Python 3.12 and returns a naive (timezone-unaware) datetime. This causes `TypeError` when compared with timezone-aware datetimes (e.g., from Supabase).

## Changes
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` in `backend/main.py`