### PR TITLE
fix: persist feedback to Supabase in submit_feedback endpoint (closes…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2783,6 +2783,7 @@ def submit_feedback(
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
 
+        await feedback_client.table("feedback").insert(feedback_record).execute()
 @app.get("/api/user-preferences/{user_id}")
 def get_user_preferences(user_id: str):
 


### PR DESCRIPTION
Fixes #955

## Summary

The `submit_feedback()` handler was building a `feedback_record` dict but never persisting it — all feedback was silently discarded.

## Changes
- Added `await feedback_client.table("feedback").insert(feedback_record).execute()` to persist feedback to Supabase