### PR TITLE
feat(1729): implement websocket-based progressive loading

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ import logging
 import math
 import secrets
 
+import asyncio
 import json
 from urllib.parse import urlsplit
 from redis import Redis
@@ -2471,12 +2472,29 @@ async def websocket_recommendations(websocket: WebSocket):
             )
 
             await websocket.send_json({
-                "type": "recommendations",
-                "query_item": request_payload.item_title,
-                "recommendations": recs,
+                "type": "recommendations_start",
                 "payload": {
                     "query_item": request_payload.item_title,
-                    "recommendations": recs,
+                    "total_results": len(recs)
+                },
+            })
+
+            chunk_size = 4
+            for i in range(0, len(recs), chunk_size):
+                chunk = recs[i:i + chunk_size]
+                await websocket.send_json({
+                    "type": "recommendations_chunk",
+                    "payload": {
+                        "recommendations": chunk,
+                    },
+                })
+                # Simulate progressive loading delay
+                await asyncio.sleep(0.3)
+
+            await websocket.send_json({
+                "type": "recommendations_complete",
+                "payload": {
+                    "query_item": request_payload.item_title,
                 },
             })
 

--- a/frontend/js/recommendations.js
+++ b/frontend/js/recommendations.js
@@ -100,6 +100,22 @@ export function initRecommendationSocket() {
         return;
       }
 
+      if (data.type === 'recommendations_start') {
+        clearTimeout(realtimeFallbackTimer);
+        renderRecommendations({ recommendations: [], has_history: data.payload?.has_history }, false);
+        return;
+      }
+
+      if (data.type === 'recommendations_chunk') {
+        renderRecommendations(data.payload || data, true);
+        return;
+      }
+
+      if (data.type === 'recommendations_complete') {
+        // Progressive loading finished
+        return;
+      }
+
       if (data.type === 'recommendations') {
         clearTimeout(realtimeFallbackTimer);
         renderRecommendations(data.payload || data);

--- a/tests/test_realtime_recommendations.py
+++ b/tests/test_realtime_recommendations.py
@@ -55,12 +55,20 @@ def realtime_client():
 def test_recommendations_websocket_streams_updates(realtime_client):
     with realtime_client.websocket_connect("/ws/recommendations") as websocket:
         websocket.send_json({"item_title": "Alpha", "top_n": 2})
-        payload = websocket.receive_json()
-
-    assert payload["type"] == "recommendations"
-    assert payload["query_item"] == "Alpha"
-    assert len(payload["recommendations"]) == 2
-    assert all(item["title"] != "Alpha" for item in payload["recommendations"])
+        start_payload = websocket.receive_json()
+        assert start_payload["type"] == "recommendations_start"
+        assert start_payload["payload"]["query_item"] == "Alpha"
+        
+        recs = []
+        while True:
+            payload = websocket.receive_json()
+            if payload["type"] == "recommendations_complete":
+                break
+            assert payload["type"] == "recommendations_chunk"
+            recs.extend(payload["payload"]["recommendations"])
+            
+    assert len(recs) == 2
+    assert all(item["title"] != "Alpha" for item in recs)
 
 def test_recommendations_websocket_accepts_structured_event(realtime_client):
     with realtime_client.websocket_connect("/ws/recommendations") as websocket:
@@ -68,11 +76,19 @@ def test_recommendations_websocket_accepts_structured_event(realtime_client):
             "type": "recommendation_request",
             "payload": {"item_title": "Alpha", "top_n": 2},
         })
-        payload = websocket.receive_json()
-
-    assert payload["type"] == "recommendations"
-    assert payload["payload"]["query_item"] == "Alpha"
-    assert len(payload["payload"]["recommendations"]) == 2
+        start_payload = websocket.receive_json()
+        assert start_payload["type"] == "recommendations_start"
+        assert start_payload["payload"]["query_item"] == "Alpha"
+        
+        recs = []
+        while True:
+            payload = websocket.receive_json()
+            if payload["type"] == "recommendations_complete":
+                break
+            assert payload["type"] == "recommendations_chunk"
+            recs.extend(payload["payload"]["recommendations"])
+            
+    assert len(recs) == 2
 
 
 def test_recommendations_websocket_rejects_invalid_payload(realtime_client):
@@ -117,7 +133,8 @@ def test_recommendations_websocket_rejects_unsupported_event(realtime_client):
     assert payload["error"]["code"] == "UNSUPPORTED_EVENT"
 
 def post_with_csrf(client, url, payload):
-    token = "a" * 64
+    resp = client.get("/api/csrf-token")
+    token = resp.json()["csrfToken"]
     origin = "http://testserver"
     client.cookies.set("csrftoken", token)
     return client.post(


### PR DESCRIPTION
## What changed
- Added `recommendations_start`, `recommendations_chunk`, and `recommendations_complete` WebSocket event types.
- Streamed recommendation results from the backend in chunks (size 4), spaced by 300ms delays to achieve progressive loading.
- Updated `frontend/js/recommendations.js` to clear recommendations on the `start` event and append to the grid on `chunk` events.
- Updated tests in `test_realtime_recommendations.py` to aggregate chunk payloads.

## Why
To implement WebSocket-Based Real-Time Recommendation Streaming with Progressive Loading (Issue #1729).

## How to test
- Run `pytest tests/test_realtime_recommendations.py -v`.
- Observe progressive rendering in the frontend.

## Related issue
Closes #1729

DCO Sign-off: Leonagoel <leonagoel@example.com>