### PR TITLE
docs: fix unclosed code block in api examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ Change the host/port if your server runs elsewhere (e.g., Docker uses `http://lo
 ### Get server status
 ```bash
 curl http://localhost:8000/api/status
+```
+
 ---
 
 ## 07 — Evaluation


### PR DESCRIPTION
Description:

This PR fixes a broken markdown code block in the API Examples section of the README. The bash script block for checking the server status was missing a closing backtick fence, causing the subsequent horizontal rule and the "Evaluation" heading to render incorrectly as part of the code block. I added the closing backticks to ensure the markdown formatting renders properl### What changed
Added missing closing backticks (\`\`\`) to the bash code block under the "API Examples (curl)" section in the README.

### Why
The missing backticks caused the markdown parser to swallow the subsequent horizontal rule and the "07 — Evaluation" heading, rendering them incorrectly as part of the bash script block.

### How to test
Review the README markdown preview locally or on GitHub to ensure the "Get server status" code block closes correctly and the "07 — Evaluation" heading renders as a proper markdown header.

### Related issue
Closes #None