### PR TITLE
fix: self-recommendation bug and wire explain parameter (#1761, #1760)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1499,10 +1499,12 @@ async def recommend_item(
     limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
     offset: int = Query(default=0, ge=0, description="Number of items to skip"),
     user_id: str = Query(default="", description="Optional user ID for personalised scoring"),
+    explain: bool = Query(default=False, description="Include explanation for each recommendation"),
 ):
     """
     Returns paginated hybrid recommendations for the given item title.
     Supports limit/offset pagination with a pagination metadata block.
+    When explain=True, each recommendation includes an explanation field.
     """
     try:
         all_results: list[dict] = []
@@ -1536,7 +1538,7 @@ async def recommend_item(
                     collab_model = None
 
                 hybrid = HybridRecommender(content_model, collab_model, item_df)
-                all_results = hybrid.recommend(title=title, user_id=user_id or None, top_n=limit + offset)
+                all_results = hybrid.recommend(title=title, user_id=user_id or None, top_n=limit + offset, explain=explain)
         except Exception:
             logger.warning("Hybrid model unavailable, using fallback recommendations")
 

--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -591,6 +591,9 @@ class HybridRecommender:
                 )
             results.append(result)
 
+        # Filter out the query title from its own recommendations
+        results = [r for r in results if r['title'] != title]
+
         results.sort(key=lambda x: x['hybrid_score'], reverse=True)
         if not results:
             return self.get_popular_fallback_items(top_n=top_n, exclude_title=title)


### PR DESCRIPTION
## Fixes two bugs

### #1761 — HybridRecommender.recommend() returns the query item in its own results
Added filter to exclude the query title from candidates before returning results:
`results = [r for r in results if r['title'] != title]`

### #1760 — Wire explain parameter through /api/recommend and frontend
Added `explain` query parameter (default=False) to `/api/recommend` endpoint.
When `explain=true`, each recommendation includes an `explanation` string field from the hybrid model's `_build_explanation` method.