### PR TITLE
fix: remove duplicate dependency entries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,3 @@ faiss-cpu>=1.8.0
 # Pre-commit hooks
 pre-commit>=3.7
 sentence-transformers>=2.2.2
-faiss-cpu>=1.7.4
-
-# Pre-commit hooks
-pre-commit>=3.7


### PR DESCRIPTION
## Summary
- remove the duplicate `faiss-cpu` requirement
- remove the duplicate `pre-commit` requirement
- keep the stronger `faiss-cpu>=1.8.0` constraint

Fixes #1757

## Validation
- `git diff --check`
- confirmed each affected package appears once in `requirements.txt`