### PR TITLE
fix: advance infinite-scroll pagination

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1486,7 +1486,9 @@ def search_items(
         'limit': limit,
         'offset': offset,
         'total_found': len(results),
-        'results': results
+        'results': results,
+        'has_more': len(results) == limit,
+        'next_offset': offset + limit if len(results) == limit else None,
     }
 
     return final_output
@@ -3109,4 +3111,3 @@ async def reset_user_preferences(request: Request):
     except Exception as e:
         logger.error(f"Error resetting preferences for user {validated_user_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to reset user data.")
-

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1805,7 +1805,8 @@ async function loadProducts(append = false) {
     try {
         const data = await API.get(`/api/search?q=&limit=${state.perPage}&offset=${(state.page - 1) * state.perPage}&sort=${getSelectedSort()}`);
         const products = data.results || [];
-        state.totalProducts = data.total || products.length;
+        state.totalProducts = data.total ?? data.total_found ?? products.length;
+        state.hasMore = data.has_more ?? products.length === state.perPage;
         state.allProducts = append
             ? [...(state.allProducts || []), ...products]
             : [...products];
@@ -1824,8 +1825,10 @@ async function loadProducts(append = false) {
 
         // Show load more if there might be more
         if (els.loadMoreContainer) {
-            els.loadMoreContainer.hidden = products.length < state.perPage;
+            els.loadMoreContainer.hidden = !state.hasMore;
         }
+
+        state.page++;
     } catch (err) {
         els.skeletonLoader.hidden = true;
         toast('Failed to load products', 'error');

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -179,4 +179,3 @@ def test_search_rejects_oversized_offset(monkeypatch):
     response = client.get("/api/search", params={"offset": 10001})
 
     assert response.status_code == 422
-


### PR DESCRIPTION
## What was happening
When someone scrolled to the bottom of the product list, the app requested the same page again. The page counter was reset correctly, but it was never advanced after a successful request, so products were repeated.

## What changed
- advance the page counter after each successful product fetch
- stop requesting more products when the API reports that the final page was reached
- include `has_more` and `next_offset` in the search response so the UI has an explicit pagination signal

## Validation
- `node --check frontend/app.js`
- `python3 -m py_compile backend/main.py`
- `git diff --check`
- End-to-end API checks pass in CI.
- The repository flake8 job reports an existing untouched issue at `backend/main.py:3094` (`global_redis_client` is never assigned).
- Local focused pytest collection is blocked by an existing pytest/pytest-asyncio compatibility error.

Fixes #1797