### PR TITLE
fix: Remove Duplicate Methods in HybridRecommender

### DIFF
--- a/src/model/hybrid_model.py
+++ b/src/model/hybrid_model.py
@@ -179,36 +179,6 @@ class HybridRecommender:
                             self._popularity_map[title] = rc / float(max_reviews)
 
     # ------------------------- weight API -------------------------
-    def set_weights(self, alpha: float, beta: float, gamma: float):
-        """Update the scoring weights. Normalized to sum to 1."""
-        for w in (alpha, beta, gamma):
-            if math.isnan(float(w)):
-                raise ValueError("Weights must be finite numbers")
-        if any(w < 0 for w in (alpha, beta, gamma)):
-            raise ValueError("Weights must be non-negative")
-        total = float(alpha + beta + gamma)
-        if total <= 0:
-            total = 1.0
-        self.alpha = float(alpha) / total
-        self.beta = float(beta) / total
-        self.gamma = float(gamma) / total
-
-    def get_weights(self):
-        return {
-            'alpha': self.alpha,
-            'beta': self.beta,
-            'gamma': self.gamma,
-            'delta': self.delta,
-        }
-
-
-    def select_bandit_arm(self):
-        import random
-
-        if random.random() < self.epsilon:
-            return random.randint(0, len(self.bandit_arms) - 1)
-
-
     def set_weights(self, alpha, beta, gamma, delta=0.05):
         """Update the scoring weights. Normalized to sum to 1.
 
@@ -233,7 +203,6 @@ class HybridRecommender:
 
     def get_weights(self):
         return {'alpha': self.alpha, 'beta': self.beta, 'gamma': self.gamma, 'delta': self.delta}
-
 
     def select_bandit_arm(self):
         import random


### PR DESCRIPTION
## Summary

Removes duplicate method definitions in src/model/hybrid_model.py.

## What Changed

Removed duplicate definitions of:
- set_weights (kept the version with delta parameter)
- get_weights
- select_bandit_arm

The first duplicate (without delta parameter) was dead code as Python uses the second definition.

## Why

Python method shadowing caused the first set_weights without delta to be inaccessible. The delta parameter for popularity weighting could not be configured via the API. This cleanup ensures a single, complete implementation.

## How to Test

```bash
python -c "from src.model.hybrid_model import HybridRecommender; h = HybridRecommender(); h.set_weights(0.3, 0.4, 0.2, 0.1); print(h.get_weights())"
```

Closes #1817