### PR TITLE
feat: Add a CI-friendly tiny example dataset and lightweight pipeline…

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,57 @@
+# Tiny example dataset
+
+This directory includes a compact synthetic dataset for local smoke tests and contributor onboarding. The file `example_small.csv` is intentionally tiny and deterministic so it can be used in CI, local validation, and quick recommender demos without requiring network access or external services.
+
+## Purpose
+
+`example_small.csv` is meant to exercise the repository's real recommendation pipeline with a minimal but realistic interaction dataset:
+
+- multiple users
+- multiple categories
+- repeated user-item interactions across items
+- enough content overlap for content-based recommendations to be meaningful
+- enough overlap for collaborative filtering to produce stable results
+
+This dataset is not a production dataset. It is designed to be small enough for fast execution while still exercising the actual recommender stack.
+
+## Required columns
+
+The dataset includes the standard columns used by the repository's adapter and models:
+
+- `item_id`
+- `title`
+- `description`
+- `category`
+- `user_id`
+- `rating`
+- `views`
+- `purchases`
+
+The adapter will normalize these fields and fill missing defaults as needed.
+
+## How to run the example
+
+From the repository root:
+
+```bash
+python scripts/run_pipeline_example.py
+```
+
+This script loads the CSV using a path derived from the repo root, runs the repository's existing preprocessing and adapter flow, builds the content, collaborative, and hybrid recommenders, and prints a top-5 recommendation list for a deterministic sample item.
+
+## Expected behavior
+
+The script should finish successfully without any external credentials, network calls, or Supabase configuration. It should print the selected source item and a ranked list of the top recommendations. Results are expected to be stable across repeated runs because the input data and recommender setup are deterministic.
+
+## Why this matters for CI and onboarding
+
+This fixture is useful because:
+
+- it is fast enough for local smoke tests and CI runners
+- it exercises the real recommender pipeline without extra setup
+- it demonstrates the repository's actual APIs without requiring production services
+- it helps contributors verify that data ingestion, preprocessing, and recommendation generation still work correctly after changes
+
+## Offline-safe notes
+
+This dataset and the example runner require no external service, API key, LLM provider, or database connection.

--- a/datasets/example_small.csv
+++ b/datasets/example_small.csv
@@ -1,0 +1,43 @@
+item_id,title,description,category,user_id,rating,views,purchases
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_01,5,120,18
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_02,4,98,15
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_03,5,140,20
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_04,3,90,12
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_05,4,110,17
+prod_01,Aurora Wireless Headphones,"Over-ear Bluetooth headphones with deep bass, plush ear cushions, and 30-hour battery life.",Electronics,user_06,5,130,19
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_01,4,80,10
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_02,5,95,14
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_03,3,72,9
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_04,4,88,11
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_05,4,84,13
+prod_02,Pine Grove Desk Lamp,"Warm ambient desk lamp with touch dimming, USB-C charging, and a compact footprint.",Home & Kitchen,user_06,4,92,12
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_01,3,75,8
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_02,5,110,18
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_03,4,86,13
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_04,5,120,19
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_05,4,91,14
+prod_03,Harbor Running Jacket,"Lightweight running jacket with breathable fabric, reflective trim, and a water-resistant finish.",Clothing,user_06,3,78,9
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_01,4,68,7
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_02,4,74,6
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_03,5,82,10
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_04,3,57,5
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_05,5,88,11
+prod_04,Northwind Cookbook,"A practical family cookbook with seasonal recipes, meal planning tips, and quick weeknight dishes.",Books,user_06,4,70,8
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_01,5,96,14
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_02,4,90,11
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_03,4,85,12
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_04,5,108,16
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_05,3,77,9
+prod_05,Evergreen Yoga Mat,"Eco-friendly yoga mat with extra cushioning, grip texture, and easy-clean material.",Sports,user_06,5,112,15
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_01,4,100,13
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_02,5,115,17
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_03,5,118,18
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_04,4,103,14
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_05,4,97,12
+prod_06,Beacon Smart Speaker,"Compact smart speaker with voice control, room-filling sound, and multi-room pairing.",Electronics,user_06,4,101,13
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_01,3,59,7
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_02,4,67,9
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_03,4,71,8
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_04,3,55,6
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_05,5,83,11
+prod_07,Bluebird City Guide,"A compact city guide with neighborhood tips, transit routes, and hidden local favorites.",Books,user_06,4,76,10

--- a/scripts/run_pipeline_example.py
+++ b/scripts/run_pipeline_example.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Lightweight smoke-test runner for the repository's recommender pipeline.
+
+Loads the pinned local example dataset, adapts and preprocesses it through the
+existing repository pipeline, builds the content + collaborative + hybrid
+recommenders, and prints a deterministic top-5 recommendation list.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.data.dataset_manager import DatasetManager
+from src.model.collaborative_model import CollaborativeRecommender
+from src.model.content_model import ContentRecommender
+from src.model.hybrid_model import HybridRecommender
+
+
+def build_example_pipeline(dataset_path: Path):
+    """Load and prepare the pinned example dataset using repo APIs."""
+    manager = DatasetManager()
+    manager.load_csv(str(dataset_path), name=dataset_path.name, catalog="example_small")
+    interaction_df, item_df = manager.merge_all()
+
+    if item_df.empty or interaction_df.empty:
+        raise ValueError("Example dataset did not load into a usable DataFrame.")
+
+    if "review_count" not in item_df.columns:
+        item_df["review_count"] = interaction_df.groupby("title").size().reindex(item_df["title"]).fillna(0).astype(int).values
+    if "avg_sentiment" not in item_df.columns:
+        item_df["avg_sentiment"] = 0.0
+
+    content_model = ContentRecommender(item_df)
+    collab_df = interaction_df[["user_id", "title", "rating"]].copy()
+    collab_model = CollaborativeRecommender(collab_df)
+    hybrid_model = HybridRecommender(content_model, collab_model, item_df)
+
+    return interaction_df, item_df, content_model, collab_model, hybrid_model
+
+
+def main() -> int:
+    random.seed(42)
+    np.random.seed(42)
+
+    dataset_path = ROOT / "datasets" / "example_small.csv"
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"Example dataset not found: {dataset_path}")
+
+    _, _, content_model, collab_model, hybrid_model = build_example_pipeline(dataset_path)
+
+    source_title = "Aurora Wireless Headphones"
+    user_id = "user_02"
+
+    content_recs = content_model.recommend(source_title, top_n=5)
+    collab_recs = collab_model.recommend(source_title, top_n=5)
+    hybrid_recs = hybrid_model.recommend(source_title, user_id=user_id, top_n=5)
+
+    if not hybrid_recs:
+        raise RuntimeError("Hybrid recommender returned no recommendations for the example dataset.")
+
+    print("Hybrid recommender smoke test")
+    print(f"Dataset: {dataset_path.name}")
+    print(f"Query title: {source_title}")
+    print(f"User: {user_id}")
+    print(f"Content candidates: {len(content_recs)}")
+    print(f"Collaborative candidates: {len(collab_recs)}")
+    print("Top recommendations:")
+    for i, rec in enumerate(hybrid_recs, start=1):
+        print(
+            f"  {i}. {rec['title']} | "
+            f"hybrid={rec['hybrid_score']:.4f} | "
+            f"content={rec.get('content_score', 0.0):.4f} | "
+            f"collab={rec.get('collab_score', 0.0):.4f}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - intentional CLI failure path
+        print(f"Pipeline example failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/test_example_small_dataset.py
+++ b/tests/test_example_small_dataset.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATASET = ROOT / "datasets" / "example_small.csv"
+RUNNER = ROOT / "scripts" / "run_pipeline_example.py"
+
+
+def test_example_small_csv_exists_and_is_valid_fixture():
+    assert DATASET.exists(), "example_small.csv should exist in the datasets directory"
+
+    stat = DATASET.stat()
+    assert 20 <= sum(1 for _ in DATASET.open("r", encoding="utf-8")) - 1 <= 100
+    assert stat.st_size < 50 * 1024, "example_small.csv should stay under 50 KB"
+
+    import pandas as pd
+
+    df = pd.read_csv(DATASET)
+    required = {"title", "description", "category", "user_id", "rating"}
+    assert required.issubset(df.columns)
+    assert df["rating"].notna().all()
+    assert df["title"].astype(str).str.len().gt(0).all()
+
+
+def test_example_runner_exits_successfully():
+    result = subprocess.run(
+        [sys.executable, str(RUNNER)],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Top recommendations:" in result.stdout
+    assert "hybrid=" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Adds a small, deterministic example dataset and lightweight offline pipeline runner for CI smoke testing and contributor onboarding.

The example pipeline:

* Uses the repository's existing DataAdapter and preprocessing pipeline
* Builds Content, Collaborative, and Hybrid recommenders using the existing APIs
* Generates top-5 recommendations from the example dataset
* Runs entirely locally without external services or network access
* Provides a reproducible smoke-test path suitable for CI

What changed:

Added `datasets/example_small.csv` containing 42 synthetic, deterministic records.
Added `scripts/run_pipeline_example.py` for a lightweight end-to-end pipeline run.
Added focused tests validating the example dataset and pipeline runner.
Added `datasets/README.md` documenting the dataset, schema, and usage.

Why

Currently, contributors need to understand and manually connect multiple parts of the recommendation pipeline before they can verify that the project works end-to-end.

This example provides a small, pinned dataset and a fast local pipeline runner that can be used for contributor onboarding, smoke testing, and future CI validation without requiring external services.

## Related issue

Closes #1825

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [x] Documentation
* [x] Tests

## How to test this

Run the example pipeline:

```bash
python scripts/run_pipeline_example.py