### PR TITLE
fix: remove duplicate _set_cached_response and _clear_response_cache functions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -328,19 +328,6 @@ def _get_cached_response(key: str):
         _cache_hits += 1
         return value
 # ── FIX #1292: HIGH PERFORMANCE RATE LIMITER PATH ──
-def _set_cached_response(key: str, value: Any) -> None:
-    try:
-        with _cache_lock:
-            _response_cache[key] = (time.time() + CACHE_TTL_SECONDS, value)
-    except (RedisError, TypeError):
-        pass
-
-def _clear_response_cache() -> None:
-    with _cache_lock:
-        _response_cache.clear()
-        global _cache_hits, _cache_misses
-        _cache_hits = 0
-        _cache_misses = 0
 
 import asyncio
 


### PR DESCRIPTION
## Summary

Removes duplicate function definitions in `backend/main.py` that caused dead code and potential confusion.

## Problem

Two functions shared the same name `_set_cached_response`:
- First (line ~331): Only wrote to in-memory cache, missing Redis support
- Second (line ~820): Correctly writes to both Redis and in-memory cache

Python's late binding caused the second to silently overwrite the first. The Redis write path was the effective implementation, but the incomplete first definition was dead code.

Similarly, `_clear_response_cache` was defined twice with identical logic.

## Fix

Removed the incomplete first definitions of both functions. The remaining implementations (with Redis support) are now the sole definitions.

## Acceptance Criteria
- [x] Only one `_set_cached_response` function exists
- [x] Only one `_clear_response_cache` function exists
- [x] No visual or functional changes

Closes #910

---

*GSSoC'26 contribution*