### PR TITLE
feat: add CD pipeline publishing Docker images to GHCR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,45 @@
+name: CD
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker Image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`.github/workflows/cd.yml`) implementing Continuous Deployment via the GitHub Container Registry, as requested in #1799.

On every push/merge to `main`, the workflow:
1. Authenticates with GHCR using the repository's built-in `GITHUB_TOKEN` - no external secrets required.
2. Builds the production Docker image from the existing `Dockerfile` using Buildx with GHA layer caching.
3. Pushes to `ghcr.io/<owner>/<repo>` tagged with both `latest` and the commit SHA.

## How it was validated

- Workflow YAML parses cleanly (`yaml.safe_load`).
- Uses only official, current GitHub Actions (actions/checkout@v4, docker/setup-buildx-action@v3, docker/login-action@v3, docker/metadata-action@v5, docker/build-push-action@v6) following the same style as the repo's existing `ci.yml`.
- The `packages: write` permission is scoped per-job; no secrets beyond `GITHUB_TOKEN` are needed, so zero maintainer setup is required after merge.

Fixes #1799